### PR TITLE
feat: use child process to eval JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@accordproject/template-engine",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@accordproject/template-engine",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@accordproject/concerto-codegen": "^3.20.0",
@@ -19,7 +19,8 @@
                 "jsonpath": "^1.1.1",
                 "tar": "^6.2.0",
                 "traverse": "^0.6.8",
-                "typescript": "^4"
+                "typescript": "^4",
+                "v8-sandbox": "^3.2.10"
             },
             "devDependencies": {
                 "@accordproject/markdown-html": "^0.16.22",
@@ -1450,6 +1451,11 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@gar/promisify": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+            "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1979,6 +1985,42 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@npmcli/fs": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+            "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+            "dependencies": {
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@npmcli/move-file": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+            "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+            "deprecated": "This functionality has been moved to @npmcli/fs",
+            "dependencies": {
+                "mkdirp": "^1.0.4",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@npmcli/move-file/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@openapi-contrib/openapi-schema-to-json-schema": {
@@ -2585,6 +2627,11 @@
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
             "dev": true
         },
+        "node_modules/abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+        },
         "node_modules/acorn": {
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2642,12 +2689,34 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
             "engines": {
                 "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/agentkeepalive": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+            "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+            "dependencies": {
+                "humanize-ms": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
+        },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ajv": {
@@ -2712,7 +2781,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2743,6 +2811,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/aproba": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+            "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+        },
+        "node_modules/are-we-there-yet": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+            "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/arg": {
@@ -2907,14 +2992,20 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2992,6 +3083,106 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
+        },
+        "node_modules/cacache": {
+            "version": "16.1.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+            "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+            "dependencies": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^8.0.1",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cacache/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cacache/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cacache/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cacache/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/call-bind": {
             "version": "1.0.2",
@@ -3100,6 +3291,14 @@
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
         },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3165,6 +3364,14 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
+        "node_modules/color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "bin": {
+                "color-support": "bin.js"
+            }
+        },
         "node_modules/color/node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3219,8 +3426,12 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
@@ -3368,6 +3579,11 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+        },
         "node_modules/detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3482,8 +3698,7 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/enabled": {
             "version": "1.0.2",
@@ -3491,6 +3706,27 @@
             "integrity": "sha512-nnzgVSpB35qKrUN8358SjO1bYAmxoThECTWw9s3J0x5G8A9hokKHVDFzBjVpCoSryo6MhN8woVyascN5jheaNA==",
             "dependencies": {
                 "env-variable": "0.0.x"
+            }
+        },
+        "node_modules/encoding": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "optional": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.2"
+            }
+        },
+        "node_modules/encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/entities": {
@@ -3504,10 +3740,23 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/env-variable": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
             "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
+        },
+        "node_modules/err-code": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
@@ -4027,6 +4276,11 @@
                 "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
             }
         },
+        "node_modules/exponential-backoff": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+            "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4130,6 +4384,11 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4182,9 +4441,9 @@
             "peer": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
@@ -4265,8 +4524,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -4313,6 +4571,24 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gauge": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+            "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+            "dependencies": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/gensync": {
@@ -4400,7 +4676,6 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4495,8 +4770,7 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -4585,6 +4859,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+        },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -4609,6 +4888,11 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
+        "node_modules/http-cache-semantics": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+        },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -4627,7 +4911,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -4643,6 +4926,14 @@
             "dev": true,
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/humanize-ms": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+            "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+            "dependencies": {
+                "ms": "^2.0.0"
             }
         },
         "node_modules/iconv-lite": {
@@ -4706,16 +4997,27 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "dev": true,
             "engines": {
                 "node": ">=0.8.19"
             }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/infer-owner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
         },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -4739,6 +5041,23 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.2",
@@ -4840,7 +5159,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4865,6 +5183,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-lambda": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+            "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.2",
@@ -5028,8 +5351,7 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
         "node_modules/isobject": {
             "version": "3.0.1",
@@ -5685,6 +6007,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
         "node_modules/jsdom": {
             "version": "16.7.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -6137,6 +6464,77 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
+        "node_modules/make-fetch-happen": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+            "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+            "dependencies": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^16.1.0",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^2.0.3",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^7.0.0",
+                "ssri": "^9.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
         "node_modules/makeerror": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -6235,7 +6633,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6251,6 +6648,146 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/minipass-collect": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+            "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-collect/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-collect/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/minipass-fetch": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+            "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+            "dependencies": {
+                "minipass": "^3.1.6",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/minipass-fetch/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-fetch/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/minipass-flush": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/minipass-sized": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+            "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/minizlib": {
             "version": "2.1.2",
@@ -6300,11 +6837,24 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "node_modules/nan": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+            "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -6349,6 +6899,30 @@
                 "url": "https://opencollective.com/node-fetch"
             }
         },
+        "node_modules/node-gyp": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+            "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^6.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^12.13 || ^14.13 || >=16"
+            }
+        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6360,6 +6934,20 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
             "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
             "dev": true
+        },
+        "node_modules/nopt": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+            "dependencies": {
+                "abbrev": "^1.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -6566,6 +7154,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/npmlog": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+            "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+            "dependencies": {
+                "are-we-there-yet": "^3.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^4.0.3",
+                "set-blocking": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
@@ -6621,7 +7223,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6695,6 +7296,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6759,7 +7374,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7004,6 +7618,23 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="
+        },
+        "node_modules/promise-retry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+            "dependencies": {
+                "err-code": "^2.0.2",
+                "retry": "^0.12.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/prompts": {
@@ -7272,6 +7903,14 @@
                 "node": ">=4"
             }
         },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7286,7 +7925,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -7441,7 +8079,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/saxes": {
             "version": "5.0.1",
@@ -7484,6 +8122,11 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -7532,8 +8175,7 @@
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
@@ -7560,6 +8202,57 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "dependencies": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+            "dependencies": {
+                "agent-base": "^6.0.2",
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/socks-proxy-agent/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/source-map": {
@@ -7618,6 +8311,33 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
+        },
+        "node_modules/ssri": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+            "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+            "dependencies": {
+                "minipass": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/ssri/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ssri/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/stack-trace": {
             "version": "0.0.10",
@@ -7749,7 +8469,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -7825,7 +8544,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -8304,6 +9022,28 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
             "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
+        "node_modules/unique-filename": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+            "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+            "dependencies": {
+                "unique-slug": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/unique-slug": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+            "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -8377,6 +9117,60 @@
             "dev": true,
             "optional": true,
             "peer": true
+        },
+        "node_modules/v8-sandbox": {
+            "version": "3.2.10",
+            "resolved": "https://registry.npmjs.org/v8-sandbox/-/v8-sandbox-3.2.10.tgz",
+            "integrity": "sha512-BIIohkY8ULJ63o084YCPMVItEurrH8HIiPufbTtI6AD9HXNnC6QmJTvN97CpvakRkSk0isK4a4diSmwVG2pyFQ==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "async": "^3.2.0",
+                "axios": "^1.6.0",
+                "bindings": "^1.5.0",
+                "lodash": "^4.17.21",
+                "nan": "^2.18.0",
+                "node-gyp": "^9.0.0",
+                "signal-exit": "^4.1.0"
+            }
+        },
+        "node_modules/v8-sandbox/node_modules/async": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+        },
+        "node_modules/v8-sandbox/node_modules/axios": {
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/v8-sandbox/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/v8-sandbox/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.0",
@@ -8484,7 +9278,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -8529,6 +9322,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/wide-align": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+            "dependencies": {
+                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "node_modules/winston": {
@@ -8599,8 +9400,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/write-file-atomic": {
             "version": "4.0.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,6 +12,16 @@ const bundle = (config) => ({
 });
 
 export default [
+    {
+        input: {
+            worker: 'src/worker.js',
+        },
+        output: {
+            dir: './dist',
+            format: 'cjs',
+            sourcemap: true,
+        },
+    },
     bundle({
         plugins: [esbuild()],
         output: [

--- a/src/JavaScriptEvaluator.ts
+++ b/src/JavaScriptEvaluator.ts
@@ -38,7 +38,7 @@ type WorkItem = {
 export type EvalResponse = {
     result: any // success if not null
     timeout?: boolean // if true the promise is rejected due to timeout
-    starvaton?: boolean // if true the promise is rejected due to lack of child process
+    starvation?: boolean // if true the promise is rejected due to lack of child process
     message?: string; // if promise rejected due to a caught exception this will be set
     elapsed?: number; // the elapsed time in ms to process the work item
     maxQueueDepthExceeded?: boolean // if true the promise is rejected because the queue is full
@@ -158,10 +158,10 @@ export class JavaScriptEvaluator {
             }
             // on timeout will send SIGTERM
             const worker = child_process.fork('./dist/worker.js', { timeout: options.timeout, env: {} });
-            this.workers.push(worker);
             if (!worker.pid) {
                 throw new Error('Failed to fork child process');
             }
+            this.workers.push(worker);
             work.pid = worker.pid;
             let result: any;
             worker.on('error', (err: any) => {

--- a/src/JavaScriptEvaluator.ts
+++ b/src/JavaScriptEvaluator.ts
@@ -106,7 +106,7 @@ export class JavaScriptEvaluator {
      * @param {EvalOptions} options the options for the request
      * @returns {Promise<EvalResponse>} the async result
      */
-    evalChildProcess(request: EvalRequest, options: EvalOptions = { timeout: 10000 }): Promise<EvalResponse> {
+    async evalChildProcess(request: EvalRequest, options: EvalOptions = { timeout: 10000 }): Promise<EvalResponse> {
         // console.log('Workers count: ' + this.workers.length);
         return new Promise((resolve, reject) => {
             const now = new Date().getTime();

--- a/src/JavaScriptEvaluator.ts
+++ b/src/JavaScriptEvaluator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
 import child_process from 'child_process';
 import jp from 'jsonpath';
 import dayjs from 'dayjs';
+import { EventEmitter } from 'node:events';
 
 export type EvalOptions = {
     timeout: number
@@ -25,55 +27,149 @@ export type EvalRequest = {
     arguments: any[] // these have to be serializable to JSON!
 }
 
+type WorkItem = {
+    pid?: number;
+    timerId?: any;
+    startTime: number;
+    expireTime: number;
+    request: EvalRequest;
+    resolve: (result: any) => void;
+    reject: (result: any) => void;
+}
+
 export type EvalResponse = {
     result: any // success if not null
     timeout?: boolean // if true the promise is rejected
     message?: string; // if promise rejected due to a caught exception this will be set
+    elapsed?: number;
+}
+
+export type JavaScriptEvaluatorOptions = {
+    waitInterval: number;
+    maxQueueDepth: number;
+    maxWorkers: number;
+}
+
+type ChildProcess = {
+    pid?: number
+} & EventEmitter;
+
+async function sleep(msec: number) {
+    return new Promise(resolve => setTimeout(resolve, msec));
 }
 
 export class JavaScriptEvaluator {
-    static async evalDangerous(request: EvalRequest) : Promise<EvalResponse> {
-        return new Promise((resolve,reject) => {
+    options: JavaScriptEvaluatorOptions;
+    workers: Array<ChildProcess>; // child processes
+    queue: Array<WorkItem>; // queue of work to do
+
+    constructor(options: JavaScriptEvaluatorOptions) {
+        this.options = options;
+        this.workers = [];
+        this.queue = [];
+    }
+
+    async evalDangerous(request: EvalRequest): Promise<EvalResponse> {
+        return new Promise((resolve, reject) => {
             try {
+                const start = new Date().getTime();
                 const fun = new Function(...['dayjs', 'jp', ...request.argumentNames], request.code);
                 const result = fun(...[dayjs, jp, ...request.arguments]);
-                resolve({result});
+                const end = new Date().getTime();
+                resolve({ result, elapsed: end-start });
             }
-            catch(err:any) {
+            catch (err: any) {
                 reject({
                     message: err.message
                 });
             }
         });
     }
-    static async evalSafe(request: EvalRequest, options: EvalOptions = { timeout: 5000 }) : Promise<EvalResponse> {
+    evalSafe(request: EvalRequest, options: EvalOptions = { timeout: 10000 }): Promise<EvalResponse> {
+        // console.log('Workers count: ' + this.workers.length);
         return new Promise((resolve, reject) => {
+            const now = new Date().getTime();
+            const workItem: WorkItem = {
+                startTime: now,
+                expireTime: now + options.timeout,
+                request,
+                resolve,
+                reject
+            };
+            this.processQueue(workItem, options);
+        });
+    }
+    private processQueue(workItem: WorkItem, options: EvalOptions) {
+        const now = new Date().getTime();
+        if(this.queue.length > this.options.maxQueueDepth) {
+            workItem.reject({ timeout: true, maxQueueDepth: true, elapsed: now - workItem.startTime });
+        }
+        else {
+            this.queue.push(workItem);
+            const notExpired = this.queue.filter(w => (now < w.expireTime));
+            const expired = this.queue.filter(w => (now >= w.expireTime));
+            this.queue = notExpired;
+            expired.forEach(w => {
+                w.reject({ timeout: true, starvation: true, elapsed: now - w.startTime });
+            });
+            const next = this.queue.shift();
+            if (next) {
+                if (this.workers.length < this.options.maxWorkers) {
+                    this.doWork(next, options)
+                        .then(result => next.resolve(result))
+                        .catch(error => next.reject(error));
+                }
+                else {
+                    sleep(this.options.waitInterval)
+                        .then(() => {
+                            this.processQueue(next, options);
+                        });
+                }
+            }
+        }
+    }
+    private doWork(work: WorkItem, options: EvalOptions = { timeout: 5000 }): Promise<EvalResponse> {
+        return new Promise((resolve, reject) => {
+            const start = new Date().getTime();
             // check for browser
-            if(!child_process.fork) {
-                reject({message: 'Cannot use evalSafe because child_process.fork is not defined.'});
+            if (!child_process.fork) {
+                reject({ message: 'Cannot use evalSafe because child_process.fork is not defined.' });
             }
             // on timeout will send SIGTERM
-            const worker = child_process.fork('./dist/worker.js', {timeout: options.timeout, env: {} });
-            let result:any;
+            const worker = child_process.fork('./dist/worker.js', { timeout: options.timeout, env: {} });
+            this.workers.push(worker);
+            if (!worker.pid) {
+                throw new Error('Failed to fork child process');
+            }
+            work.pid = worker.pid;
+            let result: any;
             worker.on('error', (err: any) => {
-                reject({message: err.message});
+                this.workers = this.workers.filter((w: ChildProcess) => w.pid !== worker.pid);
+                const end = new Date().getTime();
+                reject({ message: err.message, elapsed: end-start });
             });
             worker.on('message', (msg: any) => {
                 result = msg;
             });
             worker.on('exit', (code: any) => {
-                if(code === null) {
-                    reject({timeout: true});
+                if (code === null) {
+                    this.workers = this.workers.filter((w: ChildProcess) => w.pid !== worker.pid);
+                    const end = new Date().getTime();
+                    reject({ timeout: true, elapsed: end-start });
                 }
                 else if (code === 0 && result) {
                     // result will be undefined
                     // if the user code called process.exit()...
-                    resolve(result);
+                    this.workers = this.workers.filter((w: ChildProcess) => w.pid !== worker.pid);
+                    const end = new Date().getTime();
+                    resolve({...result, elapsed: end-start});
                 } else {
-                    reject({code, result});
+                    this.workers = this.workers.filter((w: ChildProcess) => w.pid !== worker.pid);
+                    const end = new Date().getTime();
+                    reject({ code, result, elapsed: end-start});
                 }
             });
-            worker.send(request);
+            worker.send(work.request);
         });
     }
 }

--- a/src/JavaScriptEvaluator.ts
+++ b/src/JavaScriptEvaluator.ts
@@ -62,7 +62,7 @@ async function sleep(msec: number) {
  * This class implements two JS function evaluation strategies:
  * 1. evalDangerously which creates a dynamic function and run it in-process
  * This should only be used with trusted code, or within a sandbox (e.g. the browser)
- * 2. evalChildProcess which spins up a child node process to eval the function
+ * 2. evalChildProcess which spins up a child Node process to eval the function
  * The maximum number of child processes is capped via JavaScriptEvaluatorOptions
  * as well as the maximum queue depth for the queue used to wait for a free worker
  * child process. Not that to prevent cross-request contamination
@@ -154,7 +154,7 @@ export class JavaScriptEvaluator {
             const start = new Date().getTime();
             // check for browser
             if (!child_process.fork) {
-                reject({ message: 'Cannot use evalSafe because child_process.fork is not defined.' });
+                reject({ message: 'Cannot use evalChildProcess because child_process.fork is not defined.' });
             }
             // on timeout will send SIGTERM
             const worker = child_process.fork('./dist/worker.js', { timeout: options.timeout, env: {} });

--- a/src/JavaScriptEvaluator.ts
+++ b/src/JavaScriptEvaluator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,34 +17,37 @@ import dayjs from 'dayjs';
 import { EventEmitter } from 'node:events';
 
 export type EvalOptions = {
-    timeout: number
+    timeout: number // timeout in milliseconds for this eval request
 }
 
 export type EvalRequest = {
-    code: string,
-    argumentNames: string[]
-    arguments: any[] // these have to be serializable to JSON!
+    code: string, // JS code to eval
+    argumentNames: string[] // names of function args
+    arguments: any[] // function arg values, these have to be serializable to JSON!
 }
 
 type WorkItem = {
-    pid?: number;
-    startTime: number;
-    expireTime: number;
-    request: EvalRequest;
-    resolve: (result: any) => void;
-    reject: (result: any) => void;
+    pid?: number; // process if assigned to the workitem
+    startTime: number; // timestamp when workitem created
+    expireTime: number; // timestamp for when work must be completed
+    request: EvalRequest; // payload to process
+    resolve: (result: any) => void; // promise callback for success
+    reject: (result: any) => void; // promise callback for failure
 }
 
 export type EvalResponse = {
     result: any // success if not null
-    timeout?: boolean // if true the promise is rejected
+    timeout?: boolean // if true the promise is rejected due to timeout
+    starvaton?: boolean // if true the promise is rejected due to lack of child process
     message?: string; // if promise rejected due to a caught exception this will be set
-    elapsed?: number;
+    elapsed?: number; // the elapsed time in ms to process the work item
+    maxQueueDepthExceeded?: boolean // if true the promise is rejected because the queue is full
 }
 
 export type JavaScriptEvaluatorOptions = {
-    waitInterval: number;
-    maxWorkers: number;
+    waitInterval: number; // time to wait in ms for a free worker
+    maxWorkers: number; // the max number of worker processes
+    maxQueueDepth: number; // the max queue depth for the waiting queue
 }
 
 type ChildProcess = {
@@ -56,6 +58,16 @@ async function sleep(msec: number) {
     return new Promise(resolve => setTimeout(resolve, msec));
 }
 
+/**
+ * This class implements two JS function evaluation strategies:
+ * 1. evalDangerously which creates a dynamic function and run it in-process
+ * This should only be used with trusted code, or within a sandbox (e.g. the browser)
+ * 2. evalChildProcess which spins up a child node process to eval the function
+ * The maximum number of child processes is capped via JavaScriptEvaluatorOptions
+ * as well as the maximum queue depth for the queue used to wait for a free worker
+ * child process. Not that to prevent cross-request contamination
+ * child processes are NOT pooled and are never reused.
+ */
 export class JavaScriptEvaluator {
     options: JavaScriptEvaluatorOptions;
     workers: Array<ChildProcess>; // child processes
@@ -67,7 +79,12 @@ export class JavaScriptEvaluator {
         this.queue = [];
     }
 
-    async evalDangerous(request: EvalRequest): Promise<EvalResponse> {
+    /**
+     * Evaluates a JS function in process.
+     * @param {EvalRequest} request - the eval request
+     * @returns {Promise} a promise to the result
+     */
+    async evalDangerously(request: EvalRequest): Promise<EvalResponse> {
         return new Promise((resolve, reject) => {
             try {
                 const start = new Date().getTime();
@@ -83,7 +100,13 @@ export class JavaScriptEvaluator {
             }
         });
     }
-    evalSafe(request: EvalRequest, options: EvalOptions = { timeout: 10000 }): Promise<EvalResponse> {
+    /**
+     * Evaluates a JS function using a node child process
+     * @param {EvalRequest} request the eval request
+     * @param {EvalOptions} options the options for the request
+     * @returns {Promise<EvalResponse>} the async result
+     */
+    evalChildProcess(request: EvalRequest, options: EvalOptions = { timeout: 10000 }): Promise<EvalResponse> {
         // console.log('Workers count: ' + this.workers.length);
         return new Promise((resolve, reject) => {
             const now = new Date().getTime();
@@ -94,10 +117,14 @@ export class JavaScriptEvaluator {
                 resolve,
                 reject
             };
-            this.processQueue(workItem, options);
+            if(this.queue.length >= this.options.maxQueueDepth) {
+                reject({ maxQueueDepthExceeded: true, elapsed: 0 });
+            }
+            this.queue.push(workItem);
+            this.processQueue(options);
         });
     }
-    private processQueue(workItem: WorkItem, options: EvalOptions) {
+    private processQueue(options: EvalOptions) {
         const now = new Date().getTime();
         const notExpired = this.queue.filter(w => (now < w.expireTime));
         const expired = this.queue.filter(w => (now >= w.expireTime));
@@ -106,18 +133,23 @@ export class JavaScriptEvaluator {
             w.reject({ timeout: true, starvation: true, elapsed: now - w.startTime });
         });
         if (this.workers.length < this.options.maxWorkers) {
-            this.doWork(workItem, options)
-                .then(result => workItem.resolve(result))
-                .catch(error => workItem.reject(error));
+            // we have a free worker
+            const next = this.queue.shift();
+            if (next) {
+                this.doWork(next, options)
+                    .then(result => next.resolve(result))
+                    .catch(error => next.reject(error));
+            }
         }
         else {
+            // no free worker, so sleep and then try again
             sleep(this.options.waitInterval)
                 .then(() => {
-                    this.processQueue(workItem, options);
+                    this.processQueue(options);
                 });
         }
     }
-    private doWork(work: WorkItem, options: EvalOptions = { timeout: 5000 }): Promise<EvalResponse> {
+    private doWork(work: WorkItem, options: EvalOptions): Promise<EvalResponse> {
         return new Promise((resolve, reject) => {
             const start = new Date().getTime();
             // check for browser
@@ -147,17 +179,19 @@ export class JavaScriptEvaluator {
                     reject({ timeout: true, elapsed: end - start });
                 }
                 else if (code === 0 && result) {
-                    // result will be undefined
-                    // if the user code called process.exit()...
+                    // success!
                     this.workers = this.workers.filter((w: ChildProcess) => w.pid !== worker.pid);
                     const end = new Date().getTime();
                     resolve({ ...result, elapsed: end - start });
                 } else {
+                    // null result or non-zero code from worker means an error
+                    // result will be undefined if the user code calls process.exit()
                     this.workers = this.workers.filter((w: ChildProcess) => w.pid !== worker.pid);
                     const end = new Date().getTime();
                     reject({ code, result, elapsed: end - start });
                 }
             });
+            // send the request to the child process
             worker.send(work.request);
         });
     }

--- a/src/JavaScriptEvaluator.ts
+++ b/src/JavaScriptEvaluator.ts
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import child_process from 'child_process';
+import jp from 'jsonpath';
+import dayjs from 'dayjs';
+
+export type EvalOptions = {
+    timeout: number
+}
+
+export type EvalRequest = {
+    code: string,
+    argumentNames: string[]
+    arguments: any[] // these have to be serializable to JSON!
+}
+
+export type EvalResponse = {
+    result: any // success if not null
+    timeout?: boolean // if true the promise is rejected
+    message?: string; // if promise rejected due to a caught exception this will be set
+}
+
+export class JavaScriptEvaluator {
+    static async evalDangerous(request: EvalRequest) : Promise<EvalResponse> {
+        return new Promise((resolve,reject) => {
+            try {
+                const fun = new Function(...['dayjs', 'jp', ...request.argumentNames], request.code);
+                const result = fun(...[dayjs, jp, ...request.arguments]);
+                resolve({result});
+            }
+            catch(err:any) {
+                reject({
+                    message: err.message
+                });
+            }
+        });
+    }
+    static async evalSafe(request: EvalRequest, options: EvalOptions = { timeout: 5000 }) : Promise<EvalResponse> {
+        return new Promise((resolve, reject) => {
+            // check for browser
+            if(!child_process.fork) {
+                reject({message: 'Cannot use evalSafe because child_process.fork is not defined.'});
+            }
+            // on timeout will send SIGTERM
+            const worker = child_process.fork('./dist/worker.js', {timeout: options.timeout, env: {} });
+            let result:any;
+            worker.on('error', (err: any) => {
+                reject({message: err.message});
+            });
+            worker.on('message', (msg: any) => {
+                result = msg;
+            });
+            worker.on('exit', (code: any) => {
+                if(code === null) {
+                    reject({timeout: true});
+                }
+                else if (code === 0 && result) {
+                    // result will be undefined
+                    // if the user code called process.exit()...
+                    resolve(result);
+                } else {
+                    reject({code, result});
+                }
+            });
+            worker.send(request);
+        });
+    }
+}

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -53,6 +53,7 @@ const availableProcessors = os.availableParallelism();
 const javaScriptEvaluator = new JavaScriptEvaluator({
     maxWorkers: availableProcessors, // how many child processes
     waitInterval: 50, // how long to wait before rescheduling work
+    maxQueueDepth: 100 // how many requests to queue
 });
 
 /**
@@ -87,11 +88,11 @@ async function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: 
     }
     try {
         if(options?.sandboxJavaScriptEvaluation) {
-            const r = await javaScriptEvaluator.evalSafe({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
+            const r = await javaScriptEvaluator.evalChildProcess({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
             return (typeof r.result === 'object') ? JSON.stringify(r.result) : r.result.toString();
         }
         else {
-            const r = await javaScriptEvaluator.evalDangerous({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
+            const r = await javaScriptEvaluator.evalDangerously({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
             return (typeof r.result === 'object') ? JSON.stringify(r.result) : r.result.toString();
         }
     }

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -41,7 +41,7 @@ import { TemplateMarkToJavaScriptCompiler } from './TemplateMarkToJavaScriptComp
 import { CodeType, ICode } from './model-gen/org.accordproject.templatemark@0.5.0';
 import { GenerationOptions, joinList } from './TypeScriptRuntime';
 import { getTemplateClassDeclaration } from './utils';
-import { JavaScriptEvaluator } from './JavaScriptEvaluator';
+import { EvalResponse, JavaScriptEvaluator } from './JavaScriptEvaluator';
 
 function checkCode(code:ICode) {
     if(code.type !== CodeType.ES_2020) {
@@ -66,7 +66,7 @@ const javaScriptEvaluator = new JavaScriptEvaluator({
  * @param {GenerationOptions} options the generation options
  * @returns {object} the result of evaluating the expression against the data
  */
-async function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: string, options?: GenerationOptions): Promise<any> {
+async function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: string, options?: GenerationOptions): Promise<EvalResponse> {
     if(options?.disableJavaScriptEvaluation) {
         throw new Error('JavaScript evaluation is disabled.');
     }

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -39,8 +39,8 @@ import {
 import { TemplateMarkToJavaScriptCompiler } from './TemplateMarkToJavaScriptCompiler';
 import { CodeType, ICode } from './model-gen/org.accordproject.templatemark@0.5.0';
 import { GenerationOptions, joinList } from './TypeScriptRuntime';
-import dayjs from 'dayjs';
 import { getTemplateClassDeclaration } from './utils';
+import { JavaScriptEvaluator } from './JavaScriptEvaluator';
 
 function checkCode(code:ICode) {
     if(code.type !== CodeType.ES_2020) {
@@ -56,7 +56,7 @@ function checkCode(code:ICode) {
  * @param {GenerationOptions} options the generation options
  * @returns {object} the result of evaluating the expression against the data
  */
-function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: string, options?: GenerationOptions): object {
+async function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: string, options?: GenerationOptions): Promise<any> {
     if(options?.disableJavaScriptEvaluation) {
         throw new Error('JavaScript evaluation is disabled.');
     }
@@ -67,16 +67,11 @@ function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: string
     functionArgNames.push('data');
     functionArgNames.push('library');
     functionArgNames.push('options');
-    functionArgNames.push('dayjs');
-    functionArgNames.push('jp');
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const functionArgValues = new Array<any>();
     functionArgValues.push(data);
     functionArgValues.push(clauseLibrary);
     functionArgValues.push(options);
-    functionArgValues.push(dayjs);
-    functionArgValues.push(jp);
 
     // chop the function header and closing
     const expression = fn.substring(fn.indexOf('{') + 1, fn.lastIndexOf('}'));
@@ -84,9 +79,14 @@ function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: string
         throw new Error('Empty expression');
     }
     try {
-        const fun = new Function(...functionArgNames, expression); // SECURITY!
-        const result = fun(...functionArgValues);
-        return result;
+        if(options?.sandboxJavaScriptEvaluation) {
+            const r = await JavaScriptEvaluator.evalSafe({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
+            return (typeof r.result === 'object') ? JSON.stringify(r.result) : r.result.toString();
+        }
+        else {
+            const r = await JavaScriptEvaluator.evalDangerous({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
+            return (typeof r.result === 'object') ? JSON.stringify(r.result) : r.result.toString();
+        }
     }
     catch(err) {
         throw new Error(`Caught error ${err} evaluating ${expression} with arguments ${functionArgValues}`);
@@ -140,6 +140,102 @@ function getJsonPath(rootData:any, currentNode:any, paths:string[]) : string {
     return withPath.length > 0 ? `$${withPath.join('')}` : '$';
 }
 
+// the key is a path[] joined with '/' from the traverse library
+// the value is the evaluation result
+type UserCodeResult = Record<string, any>;
+
+/**
+ * Evaluates all the user code in a template mark document
+ * @param {*} clauseLibrary - the clause library
+ * @param {*} templateMark - the TemplateMark JSON document
+ * @param {*} data - the template data JSON
+ * @param {[GenerationOptions]} options - the generation options
+ * @returns {Promise<UserCodeResult>} a promise to a UserCodeResult
+ */
+async function evaluateUserCode(clauseLibrary:object, templateMark: object, data: TemplateData, options?:GenerationOptions): Promise<UserCodeResult> {
+    const result:UserCodeResult = {};
+    const paths = traverse(templateMark).paths();
+    for(let n=0; n < paths.length; n++) {
+        const path = paths[n];
+        const context = traverse(templateMark).get(path);
+        if (typeof context === 'object' && context.$class && typeof context.$class === 'string') {
+            const nodeClass = context.$class as string;
+            if (FORMULA_DEFINITION_RE.test(nodeClass)) {
+                if (context.code) {
+                    checkCode(context.code);
+                    result[path.join('/')] = await evaluateJavaScript(clauseLibrary, data, context.code.contents, options);
+                }
+                else {
+                    throw new Error('Formula node is missing code.');
+                }
+            }
+            else if (CONDITIONAL_DEFINITION_RE.test(nodeClass) || CLAUSE_DEFINITION_RE.test(nodeClass)) {
+                if (context.condition) {
+                    checkCode(context.condition);
+                    result[path.join('/')] = await evaluateJavaScript(clauseLibrary, data, context.condition.contents, options);
+                }
+            }
+        }
+    }
+    return result;
+}
+
+// the key is a path[] joined with '/' from the traverse library
+// the value is an array of agreementmark Item nodes for the list block
+type ListBlockResult = Record<string, any[]>;
+
+/**
+ * Generates agreementmark for all list blocks
+ * Warning: this is async and recursive
+ * @param {ModelManager} modelManager - the template model
+ * @param {*} clauseLibrary - the clause library
+ * @param {*} templateMark - the TemplateMark JSON document
+ * @param {*} data - the template data JSON
+ * @param {[GenerationOptions]} options - the generation options
+ * @returns {*} the AgreementMark JSON for the list block
+ */
+async function generateListBlocks(modelManager:ModelManager, clauseLibrary:object, templateMark: object, data: TemplateData, options?:GenerationOptions): Promise<ListBlockResult> {
+    const result:ListBlockResult = {};
+    const paths = traverse(templateMark).paths();
+    for(let n=0; n < paths.length; n++) {
+        const thisPath = paths[n];
+        const context = traverse(templateMark).get(thisPath);
+        if (typeof context === 'object' && context.$class && typeof context.$class === 'string') {
+            const nodeClass = context.$class as string;
+
+            // evaluate lists, recursing on each list item
+            if (LISTBLOCK_DEFINITION_RE.test(nodeClass)) {
+                const path = getJsonPath(templateMark, context, thisPath);
+                const variableValues = jp.query(data, path, 1);
+
+                if (variableValues.length === 0) {
+                    throw new Error(`No values found for path '${path}' in data ${data}.`);
+                }
+                else {
+                    const arrayData = variableValues[0];
+                    if(!Array.isArray(arrayData)) {
+                        throw new Error(`Values found for path '${path}' in data ${data} is not an array: ${arrayData}.`);
+                    }
+                    else {
+                        const nodes = [];
+                        for(let n=0; n < arrayData.length; n++) {
+                            const arrayItem = arrayData[n];
+                            // arrayItem is now the data for the nested generation
+                            const subResult = await generateAgreement(modelManager, clauseLibrary, context.nodes[0].nodes[0], arrayItem, options);
+                            nodes.push({
+                                $class: `${CommonMarkModel.NAMESPACE}.Item`,
+                                nodes: subResult.nodes ? subResult.nodes : []
+                            });
+                        }
+                        result[thisPath.join('/')] = nodes;
+                    }
+                }
+            }
+        }
+    }
+    return result;
+}
+
 /**
  * Generates an AgreementMark JSON document from a template plus data.
  * @param {ModelManager} modelManager - the template model
@@ -149,8 +245,13 @@ function getJsonPath(rootData:any, currentNode:any, paths:string[]) : string {
  * @param {[GenerationOptions]} options - the generation options
  * @returns {*} the AgreementMark JSON
  */
-function generateAgreement(modelManager:ModelManager, clauseLibrary:object, templateMark: object, data: TemplateData, options?:GenerationOptions): any {
+async function generateAgreement(modelManager:ModelManager, clauseLibrary:object, templateMark: object, data: TemplateData, options?:GenerationOptions): Promise<any> {
     const introspector = new Introspector(modelManager);
+    // evaluate all the user code (async)
+    const userCodeResults = await evaluateUserCode(clauseLibrary, templateMark, data, options);
+    // evaluate all list blocks (async)
+    const listBlockResults = await generateListBlocks(modelManager, clauseLibrary, templateMark, data, options);
+    // traverse the templatemark, creating an output agreementmark tree
     return traverse(templateMark).map(function (context: any) {
         let stopHere = false;
         if (typeof context === 'object' && context.$class && typeof context.$class === 'string') {
@@ -182,8 +283,7 @@ function generateAgreement(modelManager:ModelManager, clauseLibrary:object, temp
             // with the result of evaluating the JS code
             else if (FORMULA_DEFINITION_RE.test(nodeClass)) {
                 if (context.code) {
-                    checkCode(context.code);
-                    const result = evaluateJavaScript(clauseLibrary, data, context.code.contents, options);
+                    const result = userCodeResults[this.path.join('/')];
                     if(result === null) {
                         context.value = '<null>';
                     }
@@ -202,32 +302,11 @@ function generateAgreement(modelManager:ModelManager, clauseLibrary:object, temp
 
             // evaluate lists, recursing on each list item
             else if (LISTBLOCK_DEFINITION_RE.test(nodeClass)) {
-                const path = getJsonPath(templateMark, context, this.path);
-                const variableValues = jp.query(data, path, 1);
-
-                if (variableValues.length === 0) {
-                    throw new Error(`No values found for path '${path}' in data ${data}.`);
-                }
-                else {
-                    const arrayData = variableValues[0];
-                    if(!Array.isArray(arrayData)) {
-                        throw new Error(`Values found for path '${path}' in data ${data} is not an array: ${arrayData}.`);
-                    }
-                    else {
-                        context.$class = `${CommonMarkModel.NAMESPACE}.List`;
-                        delete context.elementType;
-                        delete context.name;
-                        context.nodes = arrayData.map( arrayItem => {
-                            // arrayItem is now the data for the nested traversal
-                            const subResult = generateAgreement(modelManager, clauseLibrary, context.nodes[0].nodes[0], arrayItem);
-                            return {
-                                $class: `${CommonMarkModel.NAMESPACE}.Item`,
-                                nodes: subResult.nodes ? subResult.nodes : []
-                            };
-                        });
-                        stopHere = true; // do not process child nodes, we've already done it above...
-                    }
-                }
+                context.$class = `${CommonMarkModel.NAMESPACE}.List`;
+                delete context.elementType;
+                delete context.name;
+                context.nodes = listBlockResults[this.path.join('/')];
+                stopHere = true; // do not process child nodes, we've already done it above...
             }
 
             // map over an array of items, joining them into a Text node
@@ -295,8 +374,8 @@ function generateAgreement(modelManager:ModelManager, clauseLibrary:object, temp
             // with the result of evaluating the JS code or a boolean property
             else if (CONDITIONAL_DEFINITION_RE.test(nodeClass)) {
                 if (context.condition) {
-                    checkCode(context.condition);
-                    context.isTrue = !!evaluateJavaScript(clauseLibrary, data, context.condition.contents, options) as unknown as boolean;
+                    const result = userCodeResults[this.path.join('/')];
+                    context.isTrue = !!result as unknown as boolean;
                 }
                 else {
                     const path = getJsonPath(templateMark, context, this.path);
@@ -323,7 +402,7 @@ function generateAgreement(modelManager:ModelManager, clauseLibrary:object, temp
             else if (CLAUSE_DEFINITION_RE.test(nodeClass)) {
                 if (context.condition) {
                     checkCode(context.condition);
-                    const result = !!evaluateJavaScript(clauseLibrary, data, context.condition.contents, options) as unknown as boolean;
+                    const result = !!userCodeResults[this.path.join('/')] as unknown as boolean;
                     if(!result) {
                         delete context.nodes;
                         stopHere = true;
@@ -439,7 +518,7 @@ export class TemplateMarkInterpreter {
         }
         const typedTemplateMark = this.checkTypes(templateMark);
         const jsTemplateMark = await this.compileTypeScriptToJavaScript(typedTemplateMark);
-        const ciceroMark = generateAgreement(this.modelManager, this.clauseLibrary, jsTemplateMark, data, options);
+        const ciceroMark = await generateAgreement(this.modelManager, this.clauseLibrary, jsTemplateMark, data, options);
         return this.validateCiceroMark(ciceroMark);
     }
 }

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -87,7 +87,7 @@ async function evaluateJavaScript(clauseLibrary:object, data: TemplateData, fn: 
         throw new Error('Empty expression');
     }
     try {
-        if(options?.sandboxJavaScriptEvaluation) {
+        if(options?.childProcessJavaScriptEvaluation) {
             const r = await javaScriptEvaluator.evalChildProcess({code: expression, argumentNames: functionArgNames, arguments: functionArgValues});
             return (typeof r.result === 'object') ? JSON.stringify(r.result) : r.result.toString();
         }

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -52,8 +52,7 @@ function checkCode(code:ICode) {
 const availableProcessors = os.availableParallelism();
 const javaScriptEvaluator = new JavaScriptEvaluator({
     maxWorkers: availableProcessors, // how many child processes
-    waitInterval: 200, // how long to wait before rescheduling work
-    maxQueueDepth: 1000 // maximum number of queued work items
+    waitInterval: 50, // how long to wait before rescheduling work
 });
 
 /**

--- a/src/TypeScriptRuntime.ts
+++ b/src/TypeScriptRuntime.ts
@@ -24,7 +24,7 @@ export type GenerationOptions = {
     now?: string,
     locale?: string
     disableJavaScriptEvaluation?: boolean
-    sandboxJavaScriptEvaluation?: boolean
+    childProcessJavaScriptEvaluation?: boolean
 }
 
 export function joinList(data:Array<string>, joinDef:any, options?:GenerationOptions) : string {

--- a/src/TypeScriptRuntime.ts
+++ b/src/TypeScriptRuntime.ts
@@ -21,9 +21,10 @@ const DEBUG = false;
  * for use by code generation
  */
 export type GenerationOptions = {
-    now?:string,
-    locale?:string
-    disableJavaScriptEvaluation?:boolean
+    now?: string,
+    locale?: string
+    disableJavaScriptEvaluation?: boolean
+    sandboxJavaScriptEvaluation?: boolean
 }
 
 export function joinList(data:Array<string>, joinDef:any, options?:GenerationOptions) : string {

--- a/src/TypeScriptRuntime.ts
+++ b/src/TypeScriptRuntime.ts
@@ -25,6 +25,7 @@ export type GenerationOptions = {
     locale?: string
     disableJavaScriptEvaluation?: boolean
     childProcessJavaScriptEvaluation?: boolean
+    timeout?: number
 }
 
 export function joinList(data:Array<string>, joinDef:any, options?:GenerationOptions) : string {

--- a/src/TypeScriptToJavaScriptCompiler.ts
+++ b/src/TypeScriptToJavaScriptCompiler.ts
@@ -36,6 +36,7 @@ const TYPESCRIPT_URL = process.env.TYPESCRIPT_URL ? process.env.TYPESCRIPT_URL :
 
 // https://microsoft.github.io/monaco-editor/typedoc/enums/languages.typescript.ScriptTarget.html#ES2020
 const ES2020_TARGET = 7;
+// const ES5_TARGET = 1;
 
 export class TypeScriptToJavaScriptCompiler {
     context: string;

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import dayjs from 'dayjs';
+import jp from 'jsonpath';
+
+/**
+ * This executed JS code inside a child process, so that the code
+ * has no access to the parent process and can be terminated on timeout etc
+ * We do not use Node.js Cluster to ensure that each child process that is
+ * forked is not reused and cannot be polluted by previous calls.
+ */
+process.on('message', (msg) => {
+    if (!process.send) {
+        throw new Error('Cannot communicate with parent process!');
+    }
+    // we wrap the code in "use strict" to so the code cannot access the global scope
+    const code = `"use strict";
+    ${msg.code}
+    `;
+    try {
+        // we expose just two node modules to the function: dayjs 'now' and the 'jsonpath' module
+        const argNames = ['dayjs','jp',...msg.argumentNames];
+        const args = [dayjs,jp,...msg.arguments];
+        const fun = new Function(...argNames, code);
+        const result = fun(...args);
+        process.send({ result });
+        process.exit();
+    } catch (err) {
+        // console.log(`worker: ${err} ${msg.code}`);
+        process.send({ message: err.toString() });
+        process.exit(1);
+    }
+});

--- a/src/worker.js
+++ b/src/worker.js
@@ -29,7 +29,7 @@ process.on('message', (msg) => {
     ${msg.code}
     `;
     try {
-        // we expose just two node modules to the function: dayjs 'now' and the 'jsonpath' module
+        // we expose just two node modules to the function: 'dayjs' and 'jsonpath'
         const argNames = ['dayjs','jp',...msg.argumentNames];
         const args = [dayjs,jp,...msg.arguments];
         const fun = new Function(...argNames, code);

--- a/test/GenerateOptions.test.ts
+++ b/test/GenerateOptions.test.ts
@@ -30,7 +30,7 @@ describe('template generation options', () => {
             const templateMarkTransformer = new TemplateMarkTransformer();
             const templateMarkDom = templateMarkTransformer.fromMarkdownTemplate({ content: template }, modelManager, 'contract', { verbose: false });
             const now = '2023-03-17T00:00:00.000Z';
-            return engine.generate(templateMarkDom, data, {now, sandboxJavaScriptEvaluation: false});
+            return engine.generate(templateMarkDom, data, {now, sandboxJavaScriptEvaluation: true});
         };
         await expect(f()).resolves.toMatchSnapshot();
     });

--- a/test/GenerateOptions.test.ts
+++ b/test/GenerateOptions.test.ts
@@ -19,7 +19,7 @@ describe('template generation options', () => {
         };
         await expect(f()).rejects.toThrow('JavaScript evaluation is disabled.');
     });
-    test('should evaluate a formula with sandboxJavaScriptEvaluation set to true', async () => {
+    test('should evaluate a formula with childProcessJavaScriptEvaluation set to true', async () => {
         const f = async () => {
             const model = readFileSync('./test/templates/good/helloformula/model.cto', 'utf-8');
             const template = readFileSync('./test/templates/good/helloformula/template.md', 'utf-8');
@@ -30,7 +30,7 @@ describe('template generation options', () => {
             const templateMarkTransformer = new TemplateMarkTransformer();
             const templateMarkDom = templateMarkTransformer.fromMarkdownTemplate({ content: template }, modelManager, 'contract', { verbose: false });
             const now = '2023-03-17T00:00:00.000Z';
-            return engine.generate(templateMarkDom, data, {now, sandboxJavaScriptEvaluation: true});
+            return engine.generate(templateMarkDom, data, {now, childProcessJavaScriptEvaluation: true});
         };
         await expect(f()).resolves.toMatchSnapshot();
     });

--- a/test/GenerateOptions.test.ts
+++ b/test/GenerateOptions.test.ts
@@ -19,4 +19,19 @@ describe('template generation options', () => {
         };
         await expect(f()).rejects.toThrow('JavaScript evaluation is disabled.');
     });
+    test('should evaluate a formula with sandboxJavaScriptEvaluation set to true', async () => {
+        const f = async () => {
+            const model = readFileSync('./test/templates/good/helloformula/model.cto', 'utf-8');
+            const template = readFileSync('./test/templates/good/helloformula/template.md', 'utf-8');
+            const data = JSON.parse(readFileSync('./test/templates/good/helloformula/data.json', 'utf-8'));
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(model);
+            const engine = new TemplateMarkInterpreter(modelManager, {});
+            const templateMarkTransformer = new TemplateMarkTransformer();
+            const templateMarkDom = templateMarkTransformer.fromMarkdownTemplate({ content: template }, modelManager, 'contract', { verbose: false });
+            const now = '2023-03-17T00:00:00.000Z';
+            return engine.generate(templateMarkDom, data, {now, sandboxJavaScriptEvaluation: false});
+        };
+        await expect(f()).resolves.toMatchSnapshot();
+    });
 });

--- a/test/JavaScriptEvaluator.test.ts
+++ b/test/JavaScriptEvaluator.test.ts
@@ -32,13 +32,14 @@ const availableProcessors = os.availableParallelism();
 const javaScriptEvaluator = new JavaScriptEvaluator({
     maxWorkers: availableProcessors, // how many child processes
     waitInterval: 50, // how long to wait before rescheduling work
+    maxQueueDepth: 1000 // how many requests to queue
 });
 
 describe('javascript evaluator', () => {
     test('should pass stress test with javascript safe', async () => {
         const promises = [];
         for(let n=0; n < 1000; n++) {
-            const p = javaScriptEvaluator.evalSafe(SIMPLE, {timeout: 1000});
+            const p = javaScriptEvaluator.evalChildProcess(SIMPLE, {timeout: 20000});
             promises.push(p);
         }
         return Promise.all(promises)
@@ -47,28 +48,28 @@ describe('javascript evaluator', () => {
             });
     }, 60000);
     test('should eval simple javascript safe', async () => {
-        const result = await javaScriptEvaluator.evalSafe(SIMPLE);
+        const result = await javaScriptEvaluator.evalChildProcess(SIMPLE);
         delete result.elapsed;
         expect(result).toEqual(SIMPLE_RESULT);
     });
     test('should eval simple javascript danger', async () => {
-        const result = await javaScriptEvaluator.evalDangerous(SIMPLE);
+        const result = await javaScriptEvaluator.evalDangerously(SIMPLE);
         delete result.elapsed;
         expect(result).toEqual(SIMPLE_RESULT);
     });
     test('should eval now javascript safe', async () => {
-        const result = await javaScriptEvaluator.evalSafe(NOW);
+        const result = await javaScriptEvaluator.evalChildProcess(NOW);
         delete result.elapsed;
         expect(result).toEqual(NOW_RESULT);
     });
     test('should eval now javascript danger', async () => {
-        const result = await javaScriptEvaluator.evalDangerous(NOW);
+        const result = await javaScriptEvaluator.evalDangerously(NOW);
         delete result.elapsed;
         expect(result).toEqual(NOW_RESULT);
     });
     test('should eval infinite javascript safe', async () => {
         try {
-            await javaScriptEvaluator.evalSafe(INFINITE, {timeout: 1000});
+            await javaScriptEvaluator.evalChildProcess(INFINITE, {timeout: 1000});
             expect(false).toBeTruthy();
         }
         catch(err:any) {
@@ -78,7 +79,7 @@ describe('javascript evaluator', () => {
     });
     test('should eval exception javascript safe', async () => {
         try {
-            await javaScriptEvaluator.evalSafe(EXCEPTION);
+            await javaScriptEvaluator.evalChildProcess(EXCEPTION);
             expect(false).toBeTruthy();
         }
         catch(err:any) {
@@ -88,7 +89,7 @@ describe('javascript evaluator', () => {
     });
     test('should eval crash javascript safe', async () => {
         try {
-            await javaScriptEvaluator.evalSafe(CRASH);
+            await javaScriptEvaluator.evalChildProcess(CRASH);
             expect(false).toBeTruthy();
         }
         catch(err:any) {
@@ -98,7 +99,7 @@ describe('javascript evaluator', () => {
     });
     test('should eval crash error javascript safe', async () => {
         try {
-            await javaScriptEvaluator.evalSafe(CRASH_ERROR);
+            await javaScriptEvaluator.evalChildProcess(CRASH_ERROR);
             expect(false).toBeTruthy();
         }
         catch(err:any) {

--- a/test/JavaScriptEvaluator.test.ts
+++ b/test/JavaScriptEvaluator.test.ts
@@ -32,14 +32,13 @@ const availableProcessors = os.availableParallelism();
 const javaScriptEvaluator = new JavaScriptEvaluator({
     maxWorkers: availableProcessors, // how many child processes
     waitInterval: 50, // how long to wait before rescheduling work
-    maxQueueDepth: 1000 // maximum number of queued work items
 });
 
 describe('javascript evaluator', () => {
     test('should pass stress test with javascript safe', async () => {
         const promises = [];
-        for(let n=0; n < 100; n++) {
-            const p = javaScriptEvaluator.evalSafe(SIMPLE, {timeout: 10000});
+        for(let n=0; n < 1000; n++) {
+            const p = javaScriptEvaluator.evalSafe(SIMPLE, {timeout: 1000});
             promises.push(p);
         }
         return Promise.all(promises)

--- a/test/JavaScriptEvaluator.test.ts
+++ b/test/JavaScriptEvaluator.test.ts
@@ -1,0 +1,83 @@
+import dayjs from 'dayjs';
+import { JavaScriptEvaluator } from '../src/JavaScriptEvaluator';
+
+const now = '2023-03-17T00:00:00.000Z';
+
+// simple
+const SIMPLE = {code: 'return a+b', argumentNames: ['a', 'b'], arguments: [1,2]};
+const SIMPLE_RESULT = {result: 3};
+
+// // now
+const NOW = {code: 'return dayjs(now).year() + a', argumentNames: ['a', 'now'], arguments: [1, now]};
+const NOW_RESULT = {result: dayjs(now).year()+1};
+
+// infinite
+const INFINITE = {code: 'while(true); return 42;', argumentNames: [], arguments: []};
+const INFINITE_RESULT = {timeout: true};
+
+// exception
+const EXCEPTION = {code: 'throw "my error"; return 42;', argumentNames: [], arguments: []};
+const EXCEPTION_RESULT = {code: 1, result: {message: 'my error'}};
+
+// crash - faking a successful return
+const CRASH = {code: 'process.exit(); return 42;', argumentNames: [], arguments: []};
+const CRASH_RESULT = {code: 0, result: undefined};
+
+// crash - unsuccessful return
+const CRASH_ERROR = {code: 'process.exit(1); return 42;', argumentNames: [], arguments: []};
+const CRASH_ERROR_RESULT = {code: 1, result: undefined};
+
+describe('javascript evaluator', () => {
+    test('should eval simple javascript safe', async () => {
+        const result = await JavaScriptEvaluator.evalSafe(SIMPLE);
+        expect(result).toEqual(SIMPLE_RESULT);
+    });
+    test('should eval simple javascript danger', async () => {
+        const result = await JavaScriptEvaluator.evalDangerous(SIMPLE);
+        expect(result).toEqual(SIMPLE_RESULT);
+    });
+    test('should eval now javascript safe', async () => {
+        const result = await JavaScriptEvaluator.evalSafe(NOW);
+        expect(result).toEqual(NOW_RESULT);
+    });
+    test('should eval now javascript danger', async () => {
+        const result = await JavaScriptEvaluator.evalDangerous(NOW);
+        expect(result).toEqual(NOW_RESULT);
+    });
+    test('should eval infinite javascript safe', async () => {
+        try {
+            await JavaScriptEvaluator.evalSafe(INFINITE, {timeout: 1000});
+            expect(false).toBeTruthy();
+        }
+        catch(err) {
+            expect(err).toEqual(INFINITE_RESULT);
+        }
+    });
+    test('should eval exception javascript safe', async () => {
+        try {
+            await JavaScriptEvaluator.evalSafe(EXCEPTION);
+            expect(false).toBeTruthy();
+        }
+        catch(err) {
+            expect(err).toEqual(EXCEPTION_RESULT);
+        }
+    });
+    test('should eval crash javascript safe', async () => {
+        try {
+            await JavaScriptEvaluator.evalSafe(CRASH);
+            expect(false).toBeTruthy();
+        }
+        catch(err) {
+            expect(err).toEqual(CRASH_RESULT);
+        }
+    });
+    test('should eval crash error javascript safe', async () => {
+        try {
+            await JavaScriptEvaluator.evalSafe(CRASH_ERROR);
+            expect(false).toBeTruthy();
+        }
+        catch(err) {
+            expect(err).toEqual(CRASH_ERROR_RESULT);
+        }
+    });
+});

--- a/test/JavaScriptEvaluator.test.ts
+++ b/test/JavaScriptEvaluator.test.ts
@@ -39,7 +39,7 @@ describe('javascript evaluator', () => {
     test('should pass stress test with javascript safe', async () => {
         const promises = [];
         for(let n=0; n < 1000; n++) {
-            const p = javaScriptEvaluator.evalChildProcess(SIMPLE, {timeout: 20000});
+            const p = javaScriptEvaluator.evalChildProcess(SIMPLE, {timeout: 30000});
             promises.push(p);
         }
         return Promise.all(promises)

--- a/test/TemplateMarkInterpreter.test.ts
+++ b/test/TemplateMarkInterpreter.test.ts
@@ -38,6 +38,7 @@ const GOOD_TEMPLATES_ROOT = './test/templates/good';
 const BAD_TEMPLATES_ROOT = './test/templates/bad';
 
 describe('templatemark interpreter', () => {
+    jest.setTimeout(30000);
     const goodTemplates: Array<{ name: string, content: string }> = readdirSync(GOOD_TEMPLATES_ROOT).map(dir => {
         return {
             name: dir,
@@ -76,10 +77,15 @@ describe('templatemark interpreter', () => {
             const templateMarkDom = templateMarkTransformer.fromMarkdownTemplate({ content: templateMarkup }, modelManager, 'contract', { verbose: false });
             // console.log(JSON.stringify(templateMarkDom, null, 2));
 
+            // execute without sandbox
             const now = '2023-03-17T00:00:00.000Z';
             const ciceroMark = await engine.generate(templateMarkDom, data, {now, locale: 'en'});
             expect(ciceroMark.getFullyQualifiedType()).toBe(`${CommonMarkModel.NAMESPACE}.Document`);
             expect(ciceroMark.toJSON()).toMatchSnapshot();
+
+            // check we get the same result when we execute with sandbox
+            const ciceroMarkSandbox = await engine.generate(templateMarkDom, data, {now, locale: 'en', sandboxJavaScriptEvaluation: true});
+            expect(ciceroMarkSandbox.toJSON()).toStrictEqual(ciceroMark.toJSON());
         });
     });
 

--- a/test/TemplateMarkInterpreter.test.ts
+++ b/test/TemplateMarkInterpreter.test.ts
@@ -84,7 +84,7 @@ describe('templatemark interpreter', () => {
             expect(ciceroMark.toJSON()).toMatchSnapshot();
 
             // check we get the same result when we execute with sandbox
-            const ciceroMarkSandbox = await engine.generate(templateMarkDom, data, {now, locale: 'en', sandboxJavaScriptEvaluation: true});
+            const ciceroMarkSandbox = await engine.generate(templateMarkDom, data, {now, locale: 'en', childProcessJavaScriptEvaluation: true});
             expect(ciceroMarkSandbox.toJSON()).toStrictEqual(ciceroMark.toJSON());
         });
     });

--- a/test/TypeScriptCompiler.test.ts
+++ b/test/TypeScriptCompiler.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { TypeScriptToJavaScriptCompiler } from '../src/TypeScriptToJavaScriptCompiler';
 
 describe('typescript compiler', () => {
-    test.only('should compile typescript to javascript', async () => {
+    test('should compile typescript to javascript', async () => {
 
         const code = `
 export function condition_nodes_0_nodes_13_nodes_4_nodes_0(data:TemplateModel.ITemplateData, library:any) : boolean {

--- a/test/__snapshots__/GenerateOptions.test.ts.snap
+++ b/test/__snapshots__/GenerateOptions.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`template generation options should evaluate a formula with sandboxJavaScriptEvaluation set to true 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark@0.5.0.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "Hello ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+              "elementType": "String",
+              "name": "message",
+              "value": "World",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "! Your name is ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark@0.5.0.Strong",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.ciceromark@0.6.0.Formula",
+                  "dependencies": Array [],
+                  "name": "formula_a3e0e90a2ad3601e1b208a0581e1ce6dfc5aab302d20cb2a0488d78e236096f7",
+                  "value": "5",
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": " characters long.",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;

--- a/test/__snapshots__/GenerateOptions.test.ts.snap
+++ b/test/__snapshots__/GenerateOptions.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`template generation options should evaluate a formula with sandboxJavaScriptEvaluation set to true 1`] = `
+exports[`template generation options should evaluate a formula with childProcessJavaScriptEvaluation set to true 1`] = `
 Object {
   "$class": "org.accordproject.commonmark@0.5.0.Document",
   "nodes": Array [

--- a/test/templates/good/playground/data.json
+++ b/test/templates/good/playground/data.json
@@ -15,7 +15,7 @@
     },
     "favoriteColors" : ["red","green", "blue"],
     "order" : {
-        "createdAt" : "2023-05-01",
+        "createdAt" : "2023-05-01:00:00.000Z",
         "$class" : "hello@1.0.0.Order",
         "orderLines":
         [


### PR DESCRIPTION
Adds a new generation option to the engine: `childProcessJavaScriptEvaluation` which will fork a new child Node.js process and eval the code within this new process. This ensures that user code (condition nodes, clause nodes, formulae) cannot access memory/crash/DDoS the host process.

Because JS eval is now async, some other refactoring had to be performed on the code that transforms the templatemark JSON tree to an agreementmark tree — gathering all the JS code and evaluating it, before starting the tree -> tree transformation.
