### PR TITLE
chore(ci): update GitHub Actions and add npm caching

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
       - run: npm ci
       - run: npm test
 
@@ -22,10 +23,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
           registry-url: https://registry.npmjs.org/
       - name: build and publish
         run: |


### PR DESCRIPTION
## Description

Fixes #54

Updates the [npm-publish.yml](cci:7://file:///home/shubhraj/OpenSource/template-engine/.github/workflows/npm-publish.yml:0:0-0:0) workflow to use the latest GitHub Actions versions and adds npm caching for faster builds.

## Changes

- Updated `actions/checkout` from v3 to v4
- Updated `actions/setup-node` from v3 to v4
- Added npm caching via `cache: 'npm'` parameter

## Benefits

- **Security**: v4 includes latest security patches
- **Performance**: npm caching reduces `npm ci` time on cache hits
- **Maintenance**: Aligns with GitHub's current recommendations

## Testing

- [x] Verified YAML syntax is valid
- [x] Workflow parses correctly in GitHub Actions UI
