### PR TITLE
chore(ci): add concurrency control to npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Closes #56 

Adds concurrency control to prevent duplicate workflow runs for the same release.

## Changes

- Added `concurrency` block with `cancel-in-progress: false`
- Groups runs by workflow name and git ref

## Note

`cancel-in-progress: false` is intentional as we don't want to cancel publish jobs mid-execution, just prevent parallel runs.