### PR TITLE
chore: Add concurrency control to npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [created]
 
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds concurrency control to the npm-publish workflow to prevent duplicate workflow runs for the same release.

## Changes
- Added concurrency group based on release tag name
- Enabled cancel-in-progress to stop duplicate runs
- Improves CI/CD efficiency and prevents race conditions

## Related Issue
Fixes #56

## Testing
- Workflow configuration validated
- Concurrency settings follow GitHub Actions best practices