### PR TITLE
docs: Add CNCF Sandbox Project badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the [Accord Project](https://accordproject.org) template engine. Rich-text templates are defined in TemplateMark (either as markdown files, or JSON documents) and are then merged with JSON data to produce output documents. Templates may contain [TypeScript](https://www.typescriptlang.org) expressions.
 
+[![CNCF Sandbox Project](https://img.shields.io/badge/CNCF-Sandbox%20Project-blue?logo=linux-foundation&logoColor=white)](https://www.cncf.io/projects/accord-project/)
+
 ## Resources
 
 - [Getting Started Video](https://vimeo.com/manage/videos/845273411)


### PR DESCRIPTION
## Summary
This PR adds the CNCF Sandbox Project badge to the README to showcase the project's official CNCF affiliation.

## Changes
- Added CNCF Sandbox Project badge with logo at the top of README
- Badge links to CNCF projects page
- Improves project visibility and credibility

## Related Issue
Fixes #47

## Preview
The badge appears right after the project title and description, making the CNCF affiliation immediately visible to visitors.