### PR TITLE
fix: correct spelling errors in documentation and source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ We encourage community and commercial innovation in this area!
 
 ### 3. Logic FULL
 
-Unlike some templating systems which prohibit, or minmize, logic in templates, Accord Project templates fully embrace templates that may contain sophisticated logic: conditional logic to determine what text to include, or even calculations, for example to calculate the monthly payments for a mortgage based on the term of the mortgage, the amount and the interest rate.
+Unlike some templating systems which prohibit, or minimize, logic in templates, Accord Project templates fully embrace templates that may contain sophisticated logic: conditional logic to determine what text to include, or even calculations, for example to calculate the monthly payments for a mortgage based on the term of the mortgage, the amount and the interest rate.
 
 ### 4. Type-safety
 

--- a/src/TemplateMarkNodes.ts
+++ b/src/TemplateMarkNodes.ts
@@ -32,7 +32,7 @@ export const FOREACH_DEFINITION_RE = /^(org\.accordproject\.templatemark)@(.+)\.
 export type TemplateData = Record<string, unknown>;
 
 /**
- * TemplateMark nodes that implicity change the data access scope
+ * TemplateMark nodes that implicitly change the data access scope
  * by specifying the name of a property on the node.
  */
 export const NAVIGATION_NODES = [

--- a/test/TemplateMarkInterpreter.test.ts
+++ b/test/TemplateMarkInterpreter.test.ts
@@ -100,10 +100,10 @@ describe('templatemark interpreter', () => {
 
     badTemplates.forEach(function (template) {
         test(`should fail to generate ${template.name}`, async () => {
-            const templatenName = path.parse(template.name).name;
-            const model = readFileSync(`${BAD_TEMPLATES_ROOT}/${templatenName}/model.cto`, 'utf-8');
-            const templateMarkup = readFileSync(`${BAD_TEMPLATES_ROOT}/${templatenName}/template.md`, 'utf-8');
-            const data = JSON.parse(readFileSync(`${BAD_TEMPLATES_ROOT}/${templatenName}/data.json`, 'utf-8'));
+            const templateName = path.parse(template.name).name;
+            const model = readFileSync(`${BAD_TEMPLATES_ROOT}/${templateName}/model.cto`, 'utf-8');
+            const templateMarkup = readFileSync(`${BAD_TEMPLATES_ROOT}/${templateName}/template.md`, 'utf-8');
+            const data = JSON.parse(readFileSync(`${BAD_TEMPLATES_ROOT}/${templateName}/data.json`, 'utf-8'));
             const modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(model);
             const engine = new TemplateMarkInterpreter(modelManager, CLAUSE_LIBRARY);


### PR DESCRIPTION
## fix: Correct spelling errors in documentation and source files

Fixes #62

### Description

This PR fixes 3 spelling errors discovered during a spell check audit of the repository.

### Changes

| File | Line | Typo | Correction |
|------|------|------|------------|
| [README.md](cci:7://file:///home/shubhraj/OpenSource/template-engine/README.md:0:0-0:0) | 130 | `minmize` | `minimize` |
| [src/TemplateMarkNodes.ts](cci:7://file:///home/shubhraj/OpenSource/template-engine/src/TemplateMarkNodes.ts:0:0-0:0) | 35 | `implicity` | `implicitly` |
| [test/TemplateMarkInterpreter.test.ts](cci:7://file:///home/shubhraj/OpenSource/template-engine/test/TemplateMarkInterpreter.test.ts:0:0-0:0) | 103-106 | `templatenName` | `templateName` |

### Testing

- [x] All existing tests pass
- [x] No functional changes, documentation/code quality fix only