### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Note that this module is primarily intended for tool authors, or developers embe
 ```
 npm install @accordproject/template-engine --save
 ```
- 
+
 ## License <a name="license"></a>
 Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.
 


### PR DESCRIPTION
"Fixed a small typo in the 'Why create a new template engine?' section. Changed 'minmize' to 'minimize' for better readability."