### PR TITLE
chore: enable jest test coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretest": "npm-run-all licchk lint build",
     "lint": "eslint .",
     "licchk": "license-check-and-add",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage --coverageReporters=text-summary",
     "coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
     "test:watch": "jest --watchAll",
     "updateRuntimeDependencies": "node ./scripts/updateRuntimeDependencies"
@@ -136,6 +136,13 @@
     "collectCoverage": false,
     "collectCoverageFrom": [
       "src/**/*.ts"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/",
+      "/test/",
+      "/src/model-gen/",
+      "/src/slc/model-gen/"
     ]
   },
   "optionalDependencies": {


### PR DESCRIPTION
### Description
This PR updates the `package.json` configuration to automatically generate and display a **Code Coverage Summary** whenever `npm test` is run. This aligns the developer experience with other Accord Project repositories (like `concerto`) and helps identify untested areas of the codebase.

### Changes
* **Updated `package.json` scripts**: Added `--coverage --coverageReporters=text-summary` to the test command.
* **Configured Jest**: Added `coveragePathIgnorePatterns` to exclude `node_modules`, `test/`, and auto-generated `model-gen` files from the coverage calculation to ensure the metrics reflect actual source code quality.

### Fixes
Fixes #1

### Sample Output
```text
=============================== Coverage summary ===============================
Statements   : 49.59% ( 800/1613 )
Branches     : 23.91% ( 188/786 )
Functions    : 31.25% ( 80/256 )
Lines        : 49.27% ( 782/1587 )
================================================================================

Test Suites: 1 failed, 9 passed, 10 total
Tests:       1 failed, 49 passed, 50 total
Snapshots:   32 passed, 32 total
Time:        53.737 s
Ran all test suites.
```
### Note on CI status

I observed that the current main branch has regression failures (specifically ValidationException: ... field "nodes" has a value of "undefined"). Those failures are unrelated to this configuration change, and I plan to address them in a separate PR.