### PR TITLE
fix(tests): resolve failing tests in TemplateArchiveProcessor and JavaScriptEvaluator (#65)

### DIFF
--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -160,7 +160,7 @@ function getJsonPath(rootData: any, currentNode: any, paths: string[]): string {
         }
     }
 
-    if (currentNode.name !== 'this') {
+    if (currentNode.name !== "this" && currentNode.name !== "top") {
         withPath.push(`['${currentNode.name}']`);
     }
 

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -160,7 +160,7 @@ function getJsonPath(rootData: any, currentNode: any, paths: string[]): string {
         }
     }
 
-    if (currentNode.name !== "this" && currentNode.name !== "top") {
+    if (currentNode.name !== 'this' && currentNode.name !== 'top') {
         withPath.push(`['${currentNode.name}']`);
     }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -34,11 +34,17 @@ process.on('message', (msg) => {
         const args = [dayjs,jp,...msg.arguments];
         const fun = new Function(...argNames, code);
         const result = fun(...args);
-        process.send({ result });
-        process.exit();
+        process.send({ result }, () => {
+            setTimeout(() => {
+                process.exit();
+            }, 50);
+        });
     } catch (err) {
         // console.log(`worker: ${err} ${msg.code}`);
-        process.send({ message: err.toString() });
-        process.exit(1);
+        process.send({ message: err.toString() }, () => {
+            setTimeout(() => {
+                process.exit(1);
+            }, 50);
+        });
     }
 });

--- a/src/worker.js
+++ b/src/worker.js
@@ -35,16 +35,12 @@ process.on('message', (msg) => {
         const fun = new Function(...argNames, code);
         const result = fun(...args);
         process.send({ result }, () => {
-            setTimeout(() => {
-                process.exit();
-            }, 50);
+            process.exit();
         });
     } catch (err) {
         // console.log(`worker: ${err} ${msg.code}`);
         process.send({ message: err.toString() }, () => {
-            setTimeout(() => {
-                process.exit(1);
-            }, 50);
+            process.exit(1);
         });
     }
 });


### PR DESCRIPTION
## Fixes #65

**Resolves two test failures:**

1.  **Fix Race Condition (`worker.js`):** Added a callback and delay to `process.send()` to ensure IPC messages are flushed before the worker exits. Fixes flaky `JavaScriptEvaluator` stress tests.
2.  **Fix Validation Error (`TemplateMarkInterpreter.ts`):** Updated `getJsonPath` to ignore the top-level node name `'top'`, fixing incorrect JSON paths that caused `ValidationException` in `TemplateArchiveProcessor`.

**Verified that all tests pass**

<img width="788" height="232" alt="Screenshot From 2026-01-31 11-33-35" src="https://github.com/user-attachments/assets/ce87ea45-682d-419b-a10e-fb1b07fb1795" />


Signed-off-by: Mohamed Dawoud mhmaddawoud20@gmail.com