### PR TITLE
fix: preserve parent data context for primitive optional blocks

### DIFF
--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -189,6 +189,135 @@ exports[`templatemark interpreter should generate clause-optional 1`] = `
 }
 `;
 
+exports[`templatemark interpreter should generate conditional-variables 1`] = `
+{
+  "$class": "org.accordproject.commonmark@0.5.0.Document",
+  "nodes": [
+    {
+      "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+      "nodes": [
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+          "nodes": [
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "Hello ",
+            },
+            {
+              "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+              "elementType": "String",
+              "name": "name",
+              "value": "Alice",
+            },
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": ".",
+            },
+          ],
+        },
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+          "nodes": [
+            {
+              "$class": "org.accordproject.ciceromark@0.6.0.Conditional",
+              "isTrue": true,
+              "name": "age",
+              "nodes": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "You are ",
+                },
+                {
+                  "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                  "elementType": "Integer",
+                  "name": "age",
+                  "value": "30",
+                },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": " years old.",
+                },
+              ],
+              "whenFalse": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "Age unknown.",
+                },
+              ],
+              "whenTrue": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "You are ",
+                },
+                {
+                  "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                  "elementType": "Integer",
+                  "name": "age",
+                  "value": "30",
+                },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": " years old.",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+          "nodes": [
+            {
+              "$class": "org.accordproject.ciceromark@0.6.0.Conditional",
+              "isTrue": true,
+              "name": "isActive",
+              "nodes": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "Active user: ",
+                },
+                {
+                  "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                  "elementType": "String",
+                  "name": "name",
+                  "value": "Alice",
+                },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": ".",
+                },
+              ],
+              "whenFalse": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "Inactive.",
+                },
+              ],
+              "whenTrue": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "Active user: ",
+                },
+                {
+                  "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                  "elementType": "String",
+                  "name": "name",
+                  "value": "Alice",
+                },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": ".",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`templatemark interpreter should generate formula-now 1`] = `
 {
   "$class": "org.accordproject.commonmark@0.5.0.Document",
@@ -2923,12 +3052,23 @@ exports[`templatemark interpreter should generate optional_comprehensive 1`] = `
                         {
                           "$class": "org.accordproject.ciceromark@0.6.0.Variable",
                           "elementType": "Integer",
-                          "name": "this",
+                          "name": "age",
                           "value": "30",
                         },
                       ],
                       "whenNone": [],
-                      "whenSome": [],
+                      "whenSome": [
+                        {
+                          "$class": "org.accordproject.commonmark@0.5.0.Text",
+                          "text": "Age is ",
+                        },
+                        {
+                          "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                          "elementType": "Integer",
+                          "name": "age",
+                          "value": "30",
+                        },
+                      ],
                     },
                   ],
                 },
@@ -2990,12 +3130,23 @@ exports[`templatemark interpreter should generate optional_comprehensive 1`] = `
                         {
                           "$class": "org.accordproject.ciceromark@0.6.0.Variable",
                           "elementType": "Boolean",
-                          "name": "this",
+                          "name": "active",
                           "value": "true",
                         },
                       ],
                       "whenNone": [],
-                      "whenSome": [],
+                      "whenSome": [
+                        {
+                          "$class": "org.accordproject.commonmark@0.5.0.Text",
+                          "text": "Status: ",
+                        },
+                        {
+                          "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                          "elementType": "Boolean",
+                          "name": "active",
+                          "value": "true",
+                        },
+                      ],
                     },
                   ],
                 },
@@ -3097,7 +3248,7 @@ exports[`templatemark interpreter should generate optional_comprehensive 1`] = `
                     {
                       "$class": "org.accordproject.ciceromark@0.6.0.Variable",
                       "elementType": "Integer",
-                      "name": "this",
+                      "name": "age",
                       "value": "25",
                     },
                     {
@@ -3106,7 +3257,22 @@ exports[`templatemark interpreter should generate optional_comprehensive 1`] = `
                     },
                   ],
                   "whenNone": [],
-                  "whenSome": [],
+                  "whenSome": [
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "(",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Integer",
+                      "name": "age",
+                      "value": "25",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": " years old)",
+                    },
+                  ],
                 },
               ],
               "whenNone": [],
@@ -3141,12 +3307,24 @@ exports[`templatemark interpreter should generate optional_comprehensive 1`] = `
                   "$class": "org.accordproject.ciceromark@0.6.0.FormattedVariable",
                   "elementType": "DateTime",
                   "format": "MMMM DD, YYYY",
-                  "name": "this",
+                  "name": "lastVisit",
                   "value": "December 01, 2023",
                 },
               ],
               "whenNone": [],
-              "whenSome": [],
+              "whenSome": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "Last visit: ",
+                },
+                {
+                  "$class": "org.accordproject.ciceromark@0.6.0.FormattedVariable",
+                  "elementType": "DateTime",
+                  "format": "MMMM DD, YYYY",
+                  "name": "lastVisit",
+                  "value": "December 01, 2023",
+                },
+              ],
             },
           ],
         },
@@ -3783,12 +3961,23 @@ exports[`templatemark interpreter should generate optional-nested 1`] = `
                 {
                   "$class": "org.accordproject.ciceromark@0.6.0.Variable",
                   "elementType": "Integer",
-                  "name": "this",
+                  "name": "age",
                   "value": "42",
                 },
               ],
               "whenNone": [],
-              "whenSome": [],
+              "whenSome": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "Age is provided as ",
+                },
+                {
+                  "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                  "elementType": "Integer",
+                  "name": "age",
+                  "value": "42",
+                },
+              ],
             },
           ],
         },

--- a/test/templates/good/conditional-variables/data.json
+++ b/test/templates/good/conditional-variables/data.json
@@ -1,0 +1,6 @@
+{
+  "$class": "test@1.0.0.TemplateData",
+  "age": 30,
+  "name": "Alice",
+  "isActive": true
+}

--- a/test/templates/good/conditional-variables/model.cto
+++ b/test/templates/good/conditional-variables/model.cto
@@ -1,0 +1,8 @@
+namespace test@1.0.0
+
+@template
+concept TemplateData {
+    o Integer age optional
+    o String name
+    o Boolean isActive optional
+}

--- a/test/templates/good/conditional-variables/template.md
+++ b/test/templates/good/conditional-variables/template.md
@@ -1,0 +1,5 @@
+Hello {{name}}.
+
+{{#if age}}You are {{age}} years old.{{else}}Age unknown.{{/if}}
+
+{{#if isActive}}Active user: {{name}}.{{else}}Inactive.{{/if}}

--- a/test/templates/good/optional-nested/template.md
+++ b/test/templates/good/optional-nested/template.md
@@ -53,7 +53,7 @@ Order total: {{% return '£' + order.orderLines.map(ol => ol.price * ol.quantity
 
 ### Verification
 Checking logic for top-level optionals:
-{{#optional age}}Age is provided as {{this}}{{else}}Age is hidden{{/optional}}
+{{#optional age}}Age is provided as {{age}}{{else}}Age is hidden{{/optional}}
 
 
 

--- a/test/templates/good/optional_comprehensive/template.md
+++ b/test/templates/good/optional_comprehensive/template.md
@@ -2,9 +2,9 @@
 
 ### Scalar Optional Cases
 
-1. Integer: {{#optional age}}Age is {{this}}{{else}}No age{{/optional}}
-2. String: {{#optional middleName}}Middle name: {{this}}{{else}}No middle name{{/optional}}
-3. Boolean: {{#optional active}}Status: {{this}}{{else}}Status unknown{{/optional}}
+1. Integer: {{#optional age}}Age is {{age}}{{else}}No age{{/optional}}
+2. String: {{#optional middleName}}Middle name: {{middleName}}{{else}}No middle name{{/optional}}
+3. Boolean: {{#optional active}}Status: {{active}}{{else}}Status unknown{{/optional}}
 
 ### Object Optional Cases
 
@@ -12,10 +12,10 @@
 
 ### Nested Optional Within Optional
 
-{{#optional person}}Person: {{name}} {{#optional age}}({{this}} years old){{/optional}}{{else}}No person{{/optional}}
+{{#optional person}}Person: {{name}} {{#optional age}}({{age}} years old){{/optional}}{{else}}No person{{/optional}}
 
 ### Formatted Optional
 
-{{#optional lastVisit}}Last visit: {{this as "MMMM DD, YYYY"}}{{else}}Never visited{{/optional}}
+{{#optional lastVisit}}Last visit: {{lastVisit as "MMMM DD, YYYY"}}{{else}}Never visited{{/optional}}
 
 Complete.


### PR DESCRIPTION
## Description

Fixes a bug where named variables inside `{{#optional}}` blocks with primitive types (string, number, boolean) would fail at runtime because the JSON path resolver incorrectly navigated into the property scope.

**Root cause:** `OptionalDefinition` is classified as a `NAVIGATION_NODE`, so `getJsonPath` would append the property name to the path. For `{{age}}` inside `{{#optional age}}`, this produced `$['age']['age']` instead of the correct `$['age']`. Additionally, `generateOptionalBlocks` tried to treat primitive values as objects during pre-processing.

Closes accordproject/template-playground#2

## Changes

### TemplateMarkInterpreter.ts

1. **`getJsonPath`** — Skip path navigation for `OptionalDefinition` nodes that guard primitive types (detected via `ModelUtil.isPrimitiveType`). This ensures variables inside primitive optional blocks resolve from the parent data context.

2. **`generateOptionalBlocks`** — Skip pre-processing for primitive optional values (`typeof value !== 'object'`). Primitive values don't need recursive agreement generation — the normal traverse handles them correctly with the full parent data context.

### Test Updates

- Updated `optional_comprehensive/template.md` and `optional-nested/template.md` to use named variables (e.g., `{{age}}`) instead of `{{this}}` for primitive optional blocks
- Added new `conditional-variables` test template with model, template, and data files

All 28 tests pass (27 existing + 1 new). The 3 pre-existing failures in `TemplateArchiveProcessor.test.ts` are unrelated (missing `--experimental-vm-modules` flag).

## Related

This fix works in conjunction with a companion PR on [markdown-transform](https://github.com/accordproject/markdown-transform) that addresses the type-checking (parsing) side of the same issue.

## Author Checklist

- [x] Code compiles and passes tests
- [x] New tests added for changed behavior
- [x] Existing test templates updated for consistency
- [x] Signed-off-by for DCO