### PR TITLE
fix(tests): use timezone-aware dates to prevent snapshot drift

### DIFF
--- a/test/templates/good/optional-nested/data.json
+++ b/test/templates/good/optional-nested/data.json
@@ -19,7 +19,7 @@
       "blue"
     ],
     "order": {
-      "createdAt": "2023-05-01",
+      "createdAt": "2023-05-01T00:00:00.000Z",
       "$class": "org.example.ap2.mandate@1.1.1.Order",
       "orderLines": [
         {

--- a/test/templates/good/playground/data.json
+++ b/test/templates/good/playground/data.json
@@ -15,7 +15,7 @@
     },
     "favoriteColors" : ["red","green", "blue"],
     "order" : {
-        "createdAt" : "2023-05-01:00:00.000Z",
+        "createdAt" : "2023-05-01T00:00:00.000Z",
         "$class" : "hello@1.0.0.Order",
         "orderLines":
         [


### PR DESCRIPTION
Fixes #99

Test data in `optional-nested/data.json` used `"2023-05-01"` (timezone-naive), which dayjs parses as local midnight. Since `now` is hardcoded to UTC, the day-diff formula returns different values depending on the system timezone — breaking the snapshot on non-UTC machines.

Changed both `optional-nested` and `playground` test dates to explicit UTC (`"2023-05-01T00:00:00.000Z"`). Also fixed a typo in the playground date (colon instead of `T` in the ISO separator).

All 77 tests pass, all 34 snapshots match.

Signed-off-by: Saai Aravindh Raja <saaiaravindhraja@gmail.com>