### PR TITLE
fix(template): guard optional property in nested test

### DIFF
--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -3506,37 +3506,42 @@ exports[`templatemark interpreter should generate optional-nested 1`] = `
           ],
         },
         {
-          "$class": "org.accordproject.commonmark@0.5.0.List",
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
           "nodes": [
             {
-              "$class": "org.accordproject.commonmark@0.5.0.Item",
+              "$class": "org.accordproject.ciceromark@0.6.0.Optional",
+              "elementType": "Integer",
+              "hasSome": true,
+              "name": "age",
               "nodes": [
                 {
-                  "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "- You are ",
+                },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Emph",
                   "nodes": [
                     {
-                      "$class": "org.accordproject.commonmark@0.5.0.Text",
-                      "text": "You are ",
-                    },
-                    {
-                      "$class": "org.accordproject.commonmark@0.5.0.Emph",
-                      "nodes": [
-                        {
-                          "$class": "org.accordproject.ciceromark@0.6.0.Variable",
-                          "elementType": "Integer",
-                          "name": "age",
-                          "value": "42",
-                        },
-                      ],
-                    },
-                    {
-                      "$class": "org.accordproject.commonmark@0.5.0.Text",
-                      "text": " years old",
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Integer",
+                      "name": "this",
+                      "value": "42",
                     },
                   ],
                 },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": " years old",
+                },
               ],
+              "whenNone": [],
+              "whenSome": [],
             },
+          ],
+        },
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.List",
+          "nodes": [
             {
               "$class": "org.accordproject.commonmark@0.5.0.Item",
               "nodes": [

--- a/test/templates/good/optional-nested/template.md
+++ b/test/templates/good/optional-nested/template.md
@@ -36,7 +36,7 @@
  {{country}}  
  {{/clause}}
 
-- You are *{{age}}* years old
+{{#optional age}}- You are *{{this}}* years old{{/optional}}
 - Your monthly salary is {{salary as "0,0.00 CCC"}}
 - Your favorite colours are {{#join favoriteColors}}
 


### PR DESCRIPTION
This pull request resolves a test failure in `test/TemplateMarkInterpreter.test.ts` that occurred after the stricter optional property checks were introduced in PR #53.

The `should generate optional-nested` test was failing with the error `Optional properties used without guards: age`. This was because the template was using an optional property (`age`) without a guard.

This fix wraps the `age` variable in the `test/templates/good/optional-nested/template.md` file with an `{{#optional}}` block, ensuring it conforms to the new validation rules. The corresponding test snapshot has also been updated.

Fixes #112