### PR TITLE
docs(spelling): standardize spelling for consistency

### DIFF
--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -2132,7 +2132,7 @@ exports[`templatemark interpreter should generate insurance-sub-limits-liability
                   "nodes": [
                     {
                       "$class": "org.accordproject.commonmark@0.5.0.Text",
-                      "text": "The maximum liability of the Insurer under Corporate Manslaughter and Corporate Homicide Act 2007 – Defence Costs extension C6 shall not exceed:",
+                      "text": "The maximum liability of the Insurer under Corporate Manslaughter and Corporate Homicide Act 2007 – Defense Costs extension C6 shall not exceed:",
                     },
                     {
                       "$class": "org.accordproject.commonmark@0.5.0.Softbreak",
@@ -3998,7 +3998,7 @@ exports[`templatemark interpreter should generate playground 1`] = `
                   "nodes": [
                     {
                       "$class": "org.accordproject.commonmark@0.5.0.Text",
-                      "text": "Your favorite colours are ",
+                      "text": "Your favorite colors are ",
                     },
                     {
                       "$class": "org.accordproject.commonmark@0.5.0.Text",

--- a/test/templates/good/insurance-sub-limits-liability/template.md
+++ b/test/templates/good/insurance-sub-limits-liability/template.md
@@ -2,7 +2,7 @@
 
 The Sub-Limits of Indemnity for this Policy (subject to reduction by the applicable Deductible) shall be as follows:
 
-1. The maximum liability of the Insurer under Corporate Manslaughter and Corporate Homicide Act 2007 – Defence Costs extension C6 shall not exceed: 
+1. The maximum liability of the Insurer under Corporate Manslaughter and Corporate Homicide Act 2007 – Defense Costs extension C6 shall not exceed: 
 {{corporateManslaughterMaximumLiability as "0,0.00 CCC"}} in the aggregate during any one Period of Insurance. 
 
 1. The maximum liability of the Insurer under Data Protection Act extension C9 shall not exceed:

--- a/test/templates/good/optional-nested/template.md
+++ b/test/templates/good/optional-nested/template.md
@@ -38,7 +38,7 @@
 
 - You are *{{age}}* years old
 - Your monthly salary is {{salary as "0,0.00 CCC"}}
-- Your favorite colours are {{#join favoriteColors}}
+- Your favorite colors are {{#join favoriteColors}}
 
 {{#clause order}}
 ## Orders

--- a/test/templates/good/playground/template.md
+++ b/test/templates/good/playground/template.md
@@ -11,7 +11,7 @@
 
 - You are *{{age}}* ({{age as "text"}}) years old
 - Your monthly salary is {{salary as "0,0.00 CCC"}}
-- Your favorite colours are {{#join favoriteColors}}
+- Your favorite colors are {{#join favoriteColors}}
 
 {{#clause order}}
 ## Orders


### PR DESCRIPTION
Fixes #119

This PR standardizes the spelling of several words across the documentation and template files for better consistency.

- `Defence` has been changed to `Defense`.
- `colours` has been changed to `colors`.

This was identified by running cspell across the repository's markdown files.