### PR TITLE
fix: use cross-platform Jest path in test and coverage scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "pretest": "npm-run-all licchk lint build",
     "lint": "eslint .",
     "licchk": "license-check-and-add",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage --coverageReporters=text-summary",
-    "coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
+    "test": "node --experimental-vm-modules node_modules/jest-cli/bin/jest.js --coverage --coverageReporters=text-summary",
+    "coverage": "node --experimental-vm-modules node_modules/jest-cli/bin/jest.js --coverage",
     "test:watch": "jest --watchAll",
     "updateRuntimeDependencies": "node ./scripts/updateRuntimeDependencies"
   },
@@ -39,12 +39,12 @@
   "author": "accordproject.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "@accordproject/cicero-core": "0.25.2",
-    "@accordproject/concerto-codegen": "3.32.1",
-    "@accordproject/concerto-core": "3.25.7",
-    "@accordproject/concerto-util":"3.25.7",
-    "@accordproject/markdown-common": "0.17.2",
-    "@accordproject/markdown-template": "0.17.2",
+    "@accordproject/cicero-core": "^0.24.0",
+    "@accordproject/concerto-codegen": "^3.14.0",
+    "@accordproject/concerto-core": "^3.25.0",
+    "@accordproject/concerto-util": "3.25.7",
+    "@accordproject/markdown-common": "^0.16.26",
+    "@accordproject/markdown-template": "^0.16.25",
     "@typescript/twoslash": "^3.2.9",
     "browser-or-node": "^3.0.0",
     "dayjs": "1.11.13",
@@ -55,7 +55,7 @@
     "typescript": "^5.8.2"
   },
   "devDependencies": {
-    "@accordproject/markdown-html": "0.17.2",
+    "@accordproject/markdown-html": "^0.16.25",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.23.0",
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   "author": "accordproject.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "@accordproject/cicero-core": "^0.24.0",
-    "@accordproject/concerto-codegen": "^3.14.0",
-    "@accordproject/concerto-core": "^3.25.0",
-    "@accordproject/concerto-util": "3.25.7",
-    "@accordproject/markdown-common": "^0.16.26",
-    "@accordproject/markdown-template": "^0.16.25",
+    "@accordproject/cicero-core": "0.25.2",
+    "@accordproject/concerto-codegen": "3.32.1",
+    "@accordproject/concerto-core": "3.25.7",
+    "@accordproject/concerto-util":"3.25.7",
+    "@accordproject/markdown-common": "0.17.2",
+    "@accordproject/markdown-template": "0.17.2",
     "@typescript/twoslash": "^3.2.9",
     "browser-or-node": "^3.0.0",
     "dayjs": "1.11.13",
@@ -55,7 +55,7 @@
     "typescript": "^5.8.2"
   },
   "devDependencies": {
-    "@accordproject/markdown-html": "^0.16.25",
+    "@accordproject/markdown-html": "0.17.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.23.0",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
Fixes #129

`node_modules/.bin/jest` is a bash shim on Windows, so `node` can't execute it directly. Changed to `node_modules/jest-cli/bin/jest.js` which is the actual JS entry point and works on all platforms.