### PR TITLE
fix: wrap optional `age` in guard block to fix optional-nested test

### DIFF
--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -3506,47 +3506,42 @@ exports[`templatemark interpreter should generate optional-nested 1`] = `
           ],
         },
         {
-          "$class": "org.accordproject.commonmark@0.5.0.List",
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
           "nodes": [
             {
-              "$class": "org.accordproject.commonmark@0.5.0.Item",
+              "$class": "org.accordproject.ciceromark@0.6.0.Optional",
+              "elementType": "Integer",
+              "hasSome": true,
+              "name": "age",
               "nodes": [
                 {
-                  "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": "- You are ",
+                },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Emph",
                   "nodes": [
                     {
-                      "$class": "org.accordproject.commonmark@0.5.0.Text",
-                      "text": "You are ",
-                    },
-                    {
-                      "$class": "org.accordproject.commonmark@0.5.0.Emph",
-                      "nodes": [
-                        {
-                          "$class": "org.accordproject.ciceromark@0.6.0.Optional",
-                          "elementType": "Integer",
-                          "hasSome": true,
-                          "name": "age",
-                          "nodes": [
-                            {
-                              "$class": "org.accordproject.ciceromark@0.6.0.Variable",
-                              "elementType": "Integer",
-                              "name": "this",
-                              "value": "42",
-                            },
-                          ],
-                          "whenNone": [],
-                          "whenSome": [],
-                        },
-                      ],
-                    },
-                    {
-                      "$class": "org.accordproject.commonmark@0.5.0.Text",
-                      "text": " years old",
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Integer",
+                      "name": "this",
+                      "value": "42",
                     },
                   ],
                 },
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Text",
+                  "text": " years old",
+                },
               ],
+              "whenNone": [],
+              "whenSome": [],
             },
+          ],
+        },
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.List",
+          "nodes": [
             {
               "$class": "org.accordproject.commonmark@0.5.0.Item",
               "nodes": [

--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -3522,10 +3522,20 @@ exports[`templatemark interpreter should generate optional-nested 1`] = `
                       "$class": "org.accordproject.commonmark@0.5.0.Emph",
                       "nodes": [
                         {
-                          "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                          "$class": "org.accordproject.ciceromark@0.6.0.Optional",
                           "elementType": "Integer",
+                          "hasSome": true,
                           "name": "age",
-                          "value": "42",
+                          "nodes": [
+                            {
+                              "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                              "elementType": "Integer",
+                              "name": "this",
+                              "value": "42",
+                            },
+                          ],
+                          "whenNone": [],
+                          "whenSome": [],
                         },
                       ],
                     },

--- a/test/templates/good/optional-nested/template.md
+++ b/test/templates/good/optional-nested/template.md
@@ -35,7 +35,7 @@
  {{country}}  
  {{/clause}}
 
-- You are *{{#optional age}}{{this}}{{/optional}}* years old
+{{#optional age}}- You are *{{this}}* years old{{/optional}}
 - Your monthly salary is {{salary as "0,0.00 CCC"}}
 - Your favorite colours are {{#join favoriteColors}}
 

--- a/test/templates/good/optional-nested/template.md
+++ b/test/templates/good/optional-nested/template.md
@@ -1,5 +1,5 @@
-# Optional Test
-
+# Optional Test                                                                 
+                                                                                
 {{#clause mandate}}
 > **Mandate ID:** {{mandateId}}
 
@@ -36,7 +36,7 @@
  {{country}}  
  {{/clause}}
 
-- You are *{{age}}* years old
+- You are *{{#optional age}}{{this}}{{/optional}}* years old
 - Your monthly salary is {{salary as "0,0.00 CCC"}}
 - Your favorite colours are {{#join favoriteColors}}
 

--- a/test/templates/good/optional-nested/template.md
+++ b/test/templates/good/optional-nested/template.md
@@ -1,5 +1,4 @@
-# Optional Test                                                                 
-                                                                                
+# Optional Test
 {{#clause mandate}}
 > **Mandate ID:** {{mandateId}}
 


### PR DESCRIPTION
## Summary

Fixes the failing `should generate optional-nested` test after PR #53 introduced stricter compile-time checks for optional properties.

## Problem

The `age` property is declared as `optional` in the Concerto model (`model.cto`):
```
@template
concept TemplateData {
    o String name
    o Address address
    o Integer age optional   // <-- optional
    ...
}
```

But in `template.md`, it was used directly without an `{{#optional}}` guard:
```
- You are *{{age}}* years old
```

After PR #53, the template compiler validates that all optional properties are wrapped in `{{#optional}}` blocks, causing this test to fail with:
```
Optional properties used without guards: age
```

## Fix

Wraps the bare `{{age}}` reference in a proper optional guard:
```
- You are *{{#optional age}}{{this}}{{/optional}}* years old
```

This is consistent with the existing usage at the bottom of the same template:
```
{{#optional age}}Age is provided as {{this}}{{else}}Age is hidden{{/optional}}
```

Fixes #112