### PR TITLE
fix(ci): update publish workflow to use NPM_TOKEN authentication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC / npmjs publish
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,8 +43,26 @@ jobs:
         run: |
           node ./scripts/tag.js ${{ github.event.release.tag_name }}
 
-
-      - name: publish
+      - name: build and publish
         run: |
-          npm version --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
-          npm publish --access public --provenance ${{ steps.tag.outputs.tag }} 2>&1
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          npm version --no-git-tag-version ${{ github.event.release.tag_name }}
+          npm publish --access public ${{ steps.tag.outputs.tag }} 2>&1
+
+      - name: Create PR to increment version
+        uses: peter-evans/create-pull-request@v8
+        with:
+          base: main
+          commit-message: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: true
+          branch: ap-publish-${{ github.event.release.tag_name }}
+          delete-branch: true
+          title: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'
+          body: |
+            # Increment Versions
+            Update the package.json version numbers after publishing to NPM.
+          assignees: ${{ github.actor }}
+          reviewers: ${{ github.actor }}
+          draft: false


### PR DESCRIPTION
## Summary
- Fix failing publish workflow by removing invalid `--yes` and `--exact` flags from `npm version` command
- Switch from OIDC provenance to `NPM_TOKEN` secret authentication (matches concerto-cli)
- Add `contents:write` and `pull-requests:write` permissions
- Add step to automatically create PR for version increment after publish

## Test plan
- [ ] Verify `NPM_TOKEN` secret is configured in the repository
- [ ] Create a test release to validate the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)