### PR TITLE
fix: draft() throws when {{#ulist}}/{{#olist}} contains direct variable references (#145)

### DIFF
--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -300,14 +300,37 @@ async function generateRecursiveBlocks(modelManager: ModelManager, clauseLibrary
                         throw new Error(`Values found for path '${path}' in data ${data} is not an array: ${arrayData}.`);
                     }
                     else {
+                        // The shape of the ListBlockDefinition's children depends on whether
+                        // the markdown parser produced a CommonMark List/Item wrapping. That
+                        // wrapping is only emitted when the items have leading list markers
+                        // (e.g. `- ` for ulist, `1. ` for olist). When users put direct
+                        // variable references inside `{{#ulist}}` / `{{#olist}}` with no
+                        // leading marker (see #145), the body is parsed as a single Paragraph
+                        // directly under the ListBlockDefinition.
+                        const firstChild = context.nodes[0];
+                        const hasListWrapper = firstChild &&
+                            firstChild.$class === `${CommonMarkModel.NAMESPACE}.List` &&
+                            Array.isArray(firstChild.nodes) &&
+                            firstChild.nodes.length > 0;
+                        // When wrapped, the per-iteration template is the first Item inside
+                        // the List. Otherwise the ListBlockDefinition's first child IS the
+                        // per-iteration template (typically a Paragraph).
+                        const itemTemplate = hasListWrapper ? firstChild.nodes[0] : firstChild;
                         const nodes = [];
                         for (let n = 0; n < arrayData.length; n++) {
                             const arrayItem = arrayData[n];
                             // arrayItem is now the data for the nested generation
-                            const subResult = await generateAgreement(modelManager, clauseLibrary, context.nodes[0].nodes[0], arrayItem, options);
+                            const subResult = await generateAgreement(modelManager, clauseLibrary, itemTemplate, arrayItem, options);
+                            // When the template had a List/Item wrapper, the processed Item's
+                            // children (a Paragraph) become the children of the new output Item.
+                            // Otherwise the processed block itself becomes the sole child of
+                            // the new output node, preserving a valid block hierarchy.
+                            const childNodes = hasListWrapper
+                                ? (subResult.nodes ? subResult.nodes : [])
+                                : [subResult];
                             nodes.push({
                                 $class: childNodeClass,
-                                nodes: subResult.nodes ? subResult.nodes : []
+                                nodes: childNodes
                             });
                         }
                         result[thisPath.join('/')] = nodes;

--- a/test/TemplateMarkInterpreter.test.ts
+++ b/test/TemplateMarkInterpreter.test.ts
@@ -117,4 +117,99 @@ describe('templatemark interpreter', () => {
             await expect(f()).rejects.toMatchSnapshot();
         });
     });
+
+    // Regression for https://github.com/accordproject/template-engine/issues/145.
+    // When a {{#ulist}} / {{#olist}} body contains direct variable references with no
+    // leading list marker, the markdown parser produces a Paragraph (not a List/Item
+    // wrapping) under the ListBlockDefinition. The recursion must still descend into the
+    // per-iteration template and resolve those variables against each array element.
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    describe('issue #145: direct variable references inside ulist/olist', () => {
+        const MODEL = `namespace volumediscount@1.0.0
+concept VolumeDiscount {
+    o Double volumeAbove
+    o Double rate
+}
+@template
+concept TemplateData {
+    o VolumeDiscount[] volumeDiscounts
+}`;
+        const DATA = {
+            $class: 'volumediscount@1.0.0.TemplateData',
+            volumeDiscounts: [
+                { $class: 'volumediscount@1.0.0.VolumeDiscount', volumeAbove: 100, rate: 5 },
+                { $class: 'volumediscount@1.0.0.VolumeDiscount', volumeAbove: 500, rate: 10 },
+            ]
+        };
+
+        async function renderList(content: string): Promise<any> {
+            const modelManager = new ModelManager();
+            modelManager.addCTOModel(MODEL);
+            const engine = new TemplateMarkInterpreter(modelManager, {});
+            const templateMarkTransformer = new TemplateMarkTransformer();
+            const templateMarkDom = templateMarkTransformer.fromMarkdownTemplate(
+                { content }, modelManager, 'clause', { verbose: false });
+            const ciceroMark = await engine.generate(templateMarkDom, DATA, { now: '2023-03-17T00:00:00.000Z' });
+            const json: any = ciceroMark.toJSON();
+            const found: any[] = [];
+            (function walk(n: any) {
+                if (!n) return;
+                if (n.$class === `${CommonMarkModel.NAMESPACE}.List`) found.push(n);
+                if (Array.isArray(n.nodes)) n.nodes.forEach(walk);
+            })(json);
+            return found[0];
+        }
+
+        // Asserts the rendered List has one Item per array element, each containing the
+        // variable's drafted value. Both ulist and olist hit the same code path.
+        async function expectVariablesResolved(content: string, listType: 'bullet' | 'ordered') {
+            const list = await renderList(content);
+            expect(list).toBeDefined();
+            expect(list.type).toBe(listType);
+            expect(list.nodes).toHaveLength(2);
+            const collectVariables = (item: any): Array<{ name: string, value: string }> => {
+                const out: Array<{ name: string, value: string }> = [];
+                (function walk(n: any) {
+                    if (!n) return;
+                    if (n.$class === 'org.accordproject.ciceromark@0.6.0.Variable') {
+                        out.push({ name: n.name, value: n.value });
+                    }
+                    if (Array.isArray(n.nodes)) n.nodes.forEach(walk);
+                })(item);
+                return out;
+            };
+            expect(collectVariables(list.nodes[0])).toEqual([
+                { name: 'volumeAbove', value: '100.0' },
+                { name: 'rate', value: '5.0' },
+            ]);
+            expect(collectVariables(list.nodes[1])).toEqual([
+                { name: 'volumeAbove', value: '500.0' },
+                { name: 'rate', value: '10.0' },
+            ]);
+        }
+
+        // Failure mode A: a VariableDefinition is the very first inline node, which
+        // triggered `getJsonPath` to throw `Paths must be supplied`.
+        test('ulist body starting with a variable does not throw and resolves values', async () => {
+            await expectVariablesResolved(
+                '{{#ulist volumeDiscounts}}\n{{volumeAbove}} units at {{rate}}%\n{{/ulist}}\n',
+                'bullet'
+            );
+        });
+
+        test('olist body starting with a variable does not throw and resolves values', async () => {
+            await expectVariablesResolved(
+                '{{#olist volumeDiscounts}}\n{{volumeAbove}} units at {{rate}}%\n{{/olist}}\n',
+                'ordered'
+            );
+        });
+
+        // Failure mode B: leading text means no throw, but Items were silently empty.
+        test('ulist body with leading text yields populated items', async () => {
+            await expectVariablesResolved(
+                '{{#ulist volumeDiscounts}}\nAbove {{volumeAbove}} units: {{rate}}% off\n{{/ulist}}\n',
+                'bullet'
+            );
+        });
+    });
 });

--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -4409,3 +4409,203 @@ exports[`templatemark interpreter should generate playground 1`] = `
   "xmlns": "http://commonmark.org/xml/1.0",
 }
 `;
+
+exports[`templatemark interpreter should generate volumediscountolist 1`] = `
+{
+  "$class": "org.accordproject.commonmark@0.5.0.Document",
+  "nodes": [
+    {
+      "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+      "nodes": [
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.Heading",
+          "level": "2",
+          "nodes": [
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "Volume Discount Schedule",
+            },
+          ],
+        },
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.List",
+          "delimiter": "period",
+          "nodes": [
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Item",
+              "nodes": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+                  "nodes": [
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "Above ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "volumeAbove",
+                      "value": "100.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": " units: ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "rate",
+                      "value": "5.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "% discount",
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Item",
+              "nodes": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+                  "nodes": [
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "Above ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "volumeAbove",
+                      "value": "500.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": " units: ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "rate",
+                      "value": "10.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "% discount",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          "start": "1",
+          "tight": "true",
+          "type": "ordered",
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`templatemark interpreter should generate volumediscountulist 1`] = `
+{
+  "$class": "org.accordproject.commonmark@0.5.0.Document",
+  "nodes": [
+    {
+      "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+      "nodes": [
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.Heading",
+          "level": "2",
+          "nodes": [
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "Volume Discount Schedule",
+            },
+          ],
+        },
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.List",
+          "nodes": [
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Item",
+              "nodes": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+                  "nodes": [
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "Above ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "volumeAbove",
+                      "value": "100.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": " units: ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "rate",
+                      "value": "5.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "% discount",
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Item",
+              "nodes": [
+                {
+                  "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+                  "nodes": [
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "Above ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "volumeAbove",
+                      "value": "500.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": " units: ",
+                    },
+                    {
+                      "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+                      "elementType": "Double",
+                      "name": "rate",
+                      "value": "10.0",
+                    },
+                    {
+                      "$class": "org.accordproject.commonmark@0.5.0.Text",
+                      "text": "% discount",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          "tight": "true",
+          "type": "bullet",
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;

--- a/test/templates/good/volumediscountolist/data.json
+++ b/test/templates/good/volumediscountolist/data.json
@@ -1,0 +1,15 @@
+{
+    "$class": "volumediscountolist@1.0.0.TemplateData",
+    "volumeDiscounts": [
+        {
+            "$class": "volumediscountolist@1.0.0.VolumeDiscount",
+            "volumeAbove": 100,
+            "rate": 5
+        },
+        {
+            "$class": "volumediscountolist@1.0.0.VolumeDiscount",
+            "volumeAbove": 500,
+            "rate": 10
+        }
+    ]
+}

--- a/test/templates/good/volumediscountolist/model.cto
+++ b/test/templates/good/volumediscountolist/model.cto
@@ -1,0 +1,11 @@
+namespace volumediscountolist@1.0.0
+
+concept VolumeDiscount {
+    o Double volumeAbove
+    o Double rate
+}
+
+@template
+concept TemplateData {
+    o VolumeDiscount[] volumeDiscounts
+}

--- a/test/templates/good/volumediscountolist/template.md
+++ b/test/templates/good/volumediscountolist/template.md
@@ -1,0 +1,5 @@
+## Volume Discount Schedule
+
+{{#olist volumeDiscounts}}
+Above {{volumeAbove}} units: {{rate}}% discount
+{{/olist}}

--- a/test/templates/good/volumediscountulist/data.json
+++ b/test/templates/good/volumediscountulist/data.json
@@ -1,0 +1,15 @@
+{
+    "$class": "volumediscountulist@1.0.0.TemplateData",
+    "volumeDiscounts": [
+        {
+            "$class": "volumediscountulist@1.0.0.VolumeDiscount",
+            "volumeAbove": 100,
+            "rate": 5
+        },
+        {
+            "$class": "volumediscountulist@1.0.0.VolumeDiscount",
+            "volumeAbove": 500,
+            "rate": 10
+        }
+    ]
+}

--- a/test/templates/good/volumediscountulist/model.cto
+++ b/test/templates/good/volumediscountulist/model.cto
@@ -1,0 +1,11 @@
+namespace volumediscountulist@1.0.0
+
+concept VolumeDiscount {
+    o Double volumeAbove
+    o Double rate
+}
+
+@template
+concept TemplateData {
+    o VolumeDiscount[] volumeDiscounts
+}

--- a/test/templates/good/volumediscountulist/template.md
+++ b/test/templates/good/volumediscountulist/template.md
@@ -1,0 +1,5 @@
+## Volume Discount Schedule
+
+{{#ulist volumeDiscounts}}
+Above {{volumeAbove}} units: {{rate}}% discount
+{{/ulist}}


### PR DESCRIPTION
Fixes #145.

## Root cause

When a `{{#ulist}}` / `{{#olist}}` body contains direct variable references
(e.g. `{{volumeAbove}}`) with no leading list marker (`- ` or `1. `), the
markdown parser does **not** wrap the body in a CommonMark `List > Item`
structure — it produces a `Paragraph` directly under the
`ListBlockDefinition`:

```
ListBlockDefinition
  Paragraph         <-- no List/Item wrapper
    VariableDefinition  (volumeAbove)
    ...
```

`generateRecursiveBlocks` in `src/TemplateMarkInterpreter.ts` blindly
accessed `context.nodes[0].nodes[0]`, which assumed the `List > Item`
wrapping was always present. With the wrapping absent, that path points
at a leaf inline node (a `VariableDefinition` or `Text`), and
`generateAgreement` was then called with that leaf as its root
`templateMark`.

Two failure modes followed:

1. **Throws** `Error: Paths must be supplied` from `getJsonPath` when the
   first inline node is a `VariableDefinition` (matches the
   `dist/index.js:703` stack reported in the issue): the traversal visits
   the root with an empty `this.path`, and `getJsonPath` rejects empty
   paths.
2. **Silently empty `Item`s** when the first inline node is `Text`: no
   error is thrown but each output `Item` ends up with `nodes: []`.

This is reproducible with the `src/volumediscountulist` and
`src/volumediscountolist` templates from
accordproject/cicero-template-library#484.

## Fix

Detect whether the parser produced a `CommonMark.List` wrapper and pick
the per-iteration template accordingly:

- **Wrapped** (existing behaviour preserved): descend into
  `firstChild.nodes[0]` (the `Item` template), recurse on it, and unwrap
  the processed children into each new output `Item`.
- **Unwrapped** (new path): treat `firstChild` itself (a `Paragraph`) as
  the per-iteration template and place the processed block as the sole
  child of each new output `Item`, keeping a valid
  `Item > Paragraph > inline...` hierarchy.

## Tests

- `test/templates/good/volumediscountulist` and
  `test/templates/good/volumediscountolist` — snapshot fixtures that
  exercise the failure mode through the regular `goodTemplates` loop.
- `test/TemplateMarkInterpreter.test.ts` — assertion-based regression
  block under `describe('issue #145: ...')` covering both failure modes
  (variable as the first inline node, and a leading-text inline node)
  for both `ulist` and `olist`. All three tests fail on `main` and pass
  with the fix.

Network-dependent tests in this repo (`models.accordproject.org` fetches,
child-process JS evaluation) were failing identically before and after
this change due to the sandboxed environment; they are unrelated to this
fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTyJ9tZv7WPh4ftm76Z7SP)_