### PR TITLE
fix: draft() can't resolve TypeScript helper functions defined in logic/logic.ts (#147)

### DIFF
--- a/src/TemplateArchiveProcessor.ts
+++ b/src/TemplateArchiveProcessor.ts
@@ -18,11 +18,9 @@ import { Template } from '@accordproject/cicero-core';
 import { TemplateMarkInterpreter } from './TemplateMarkInterpreter';
 import { TemplateMarkTransformer } from '@accordproject/markdown-template';
 import { transform } from '@accordproject/markdown-transform';
-import { TypeScriptToJavaScriptCompiler } from './TypeScriptToJavaScriptCompiler';
 import Script from '@accordproject/cicero-core/types/src/script';
-import { TwoSlashReturn } from '@typescript/twoslash';
 import { JavaScriptEvaluator } from './JavaScriptEvaluator';
-import { SMART_LEGAL_CONTRACT_BASE64 } from './runtime/declarations';
+import { compileUserLogic, CompiledUserLogic } from './UserLogic';
 
 export type State = object;
 export type Response = object;
@@ -66,9 +64,14 @@ export class TemplateArchiveProcessor {
         const metadata = this.template.getMetadata();
         const templateKind = metadata.getTemplateType() !== 0 ? 'clause' : 'contract';
 
+        // Compile the template's logic/logic.ts (when present) so that
+        // inline formulas {{% expr %}} can call helpers like
+        // monthlyPaymentFormula(...) declared in user code (issue #147).
+        const userLogic = await this.compileLogic();
+
         // Get the data
         const modelManager = this.template.getModelManager();
-        const engine = new TemplateMarkInterpreter(modelManager, {});
+        const engine = new TemplateMarkInterpreter(modelManager, {}, undefined, userLogic);
         const templateMarkTransformer = new TemplateMarkTransformer();
         const templateMarkDom = templateMarkTransformer.fromMarkdownTemplate(
             { content: this.template.getTemplate() }, modelManager, templateKind, {options});
@@ -83,6 +86,31 @@ export class TemplateArchiveProcessor {
     }
 
     /**
+     * Compiles the template's `logic/logic.ts` using the same TypeScript
+     * compilation pipeline that {@link trigger} and {@link init} use, but
+     * returns the result via {@link CompiledUserLogic} so it can also be
+     * consumed by {@link draft} (so inline formulas can call helpers from
+     * logic.ts — see issue #147). Returns `undefined` for non-TypeScript
+     * runtimes or when the template ships no logic.
+     */
+    private async compileLogic(): Promise<CompiledUserLogic | undefined> {
+        const logicManager = this.template.getLogicManager();
+        if (logicManager.getLanguage() !== 'typescript') {
+            return undefined;
+        }
+        const tsFiles: Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
+        const logicFile = tsFiles.find(f => f.getIdentifier() === 'logic/logic.ts') ?? tsFiles[0];
+        if (!logicFile) {
+            return undefined;
+        }
+        return compileUserLogic(
+            this.template.getModelManager(),
+            this.template.getTemplateModel().getFullyQualifiedName(),
+            logicFile.getContents(),
+        );
+    }
+
+    /**
      * Trigger the logic of a template
      * @param {object} request - the request to send to the template logic
      * @param {object} state - the current state of the template
@@ -91,48 +119,25 @@ export class TemplateArchiveProcessor {
      * @returns {Promise} the response and any events
      */
     async trigger(data: any, request: any, state?: any, currentTime?: string, utcOffset?: number): Promise<TriggerResponse> {
-        const logicManager = this.template.getLogicManager();
-        if(logicManager.getLanguage() === 'typescript') {
-            const compiledCode:Record<string, TwoSlashReturn> = {};
-            const tsFiles:Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
-            for(let n=0; n < tsFiles.length; n++) {
-                const tsFile = tsFiles[n];
-                // console.log(`Compiling ${tsFile.getIdentifier()}`);
-
-                const compiler = new TypeScriptToJavaScriptCompiler(this.template.getModelManager(),
-                    this.template.getTemplateModel().getFullyQualifiedName());
-
-                await compiler.initialize();
-
-                // add the runtime type definitions to all ts files??
-                const code = `${Buffer.from(SMART_LEGAL_CONTRACT_BASE64, 'base64').toString()}
-                ${tsFile.getContents()}`
-
-                const result = compiler.compile(code);
-                compiledCode[tsFile.getIdentifier()] = result;
-            }
-            // console.log(compiledCode['logic/logic.ts'].code);
-            const resolvedTime = currentTime ?? new Date().toISOString();
-            const resolvedOffset = utcOffset ?? 0;
-            const evaluator = new JavaScriptEvaluator();
-            const evalResponse = await evaluator.evalDangerously( {
-                templateLogic: true,
-                verbose: false,
-                functionName: 'trigger',
-                code: compiledCode['logic/logic.ts'].code, // TODO DCS - how to find the code to run?
-                argumentNames: ['data', 'request', 'state'],
-                arguments: [data, request, state, resolvedTime, resolvedOffset]
-            });
-            if(evalResponse.result) {
-                return evalResponse.result;
-            }
-            else {
-                throw new Error('Trigger failed with message: ' + evalResponse.message);
-            }
-        }
-        else {
+        const userLogic = await this.compileLogic();
+        if (!userLogic) {
             throw new Error('Only TypeScript is supported at this time');
         }
+        const resolvedTime = currentTime ?? new Date().toISOString();
+        const resolvedOffset = utcOffset ?? 0;
+        const evaluator = new JavaScriptEvaluator();
+        const evalResponse = await evaluator.evalDangerously({
+            templateLogic: true,
+            verbose: false,
+            functionName: 'trigger',
+            code: userLogic.compiledJs,
+            argumentNames: ['data', 'request', 'state'],
+            arguments: [data, request, state, resolvedTime, resolvedOffset]
+        });
+        if (evalResponse.result) {
+            return evalResponse.result;
+        }
+        throw new Error('Trigger failed with message: ' + evalResponse.message);
     }
 
     /**
@@ -142,47 +147,24 @@ export class TemplateArchiveProcessor {
      * @returns {Promise<InitResponse>} the new state
      */
     async init(data: any, currentTime?: string, utcOffset?: number): Promise<InitResponse> {
-        const logicManager = this.template.getLogicManager();
-        if(logicManager.getLanguage() === 'typescript') {
-            const compiledCode:Record<string, TwoSlashReturn> = {};
-            const tsFiles:Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
-            for(let n=0; n < tsFiles.length; n++) {
-                const tsFile = tsFiles[n];
-                // console.log(`Compiling ${tsFile.getIdentifier()}`);
-
-                const compiler = new TypeScriptToJavaScriptCompiler(this.template.getModelManager(),
-                    this.template.getTemplateModel().getFullyQualifiedName());
-
-                await compiler.initialize();
-
-                // add the runtime type definitions to all ts files??
-                const code = `${Buffer.from(SMART_LEGAL_CONTRACT_BASE64, 'base64').toString()}
-                ${tsFile.getContents()}`
-
-                const result = compiler.compile(code);
-                compiledCode[tsFile.getIdentifier()] = result;
-            }
-            // console.log(compiledCode['logic/logic.ts'].code);
-            const resolvedTime = currentTime ?? new Date().toISOString();
-            const resolvedOffset = utcOffset ?? 0;
-            const evaluator = new JavaScriptEvaluator();
-            const evalResponse = await evaluator.evalDangerously( {
-                templateLogic: true,
-                verbose: false,
-                functionName: 'init',
-                code: compiledCode['logic/logic.ts'].code, // TODO DCS - how to find the code to run?
-                argumentNames: ['data'],
-                arguments: [data, resolvedTime, resolvedOffset]
-            });
-            if(evalResponse.result) {
-                return evalResponse.result;
-            }
-            else {
-                throw new Error('Init failed with message: ' + evalResponse.message);
-            }
-        }
-        else {
+        const userLogic = await this.compileLogic();
+        if (!userLogic) {
             throw new Error('Only TypeScript is supported at this time');
         }
+        const resolvedTime = currentTime ?? new Date().toISOString();
+        const resolvedOffset = utcOffset ?? 0;
+        const evaluator = new JavaScriptEvaluator();
+        const evalResponse = await evaluator.evalDangerously({
+            templateLogic: true,
+            verbose: false,
+            functionName: 'init',
+            code: userLogic.compiledJs,
+            argumentNames: ['data'],
+            arguments: [data, resolvedTime, resolvedOffset]
+        });
+        if (evalResponse.result) {
+            return evalResponse.result;
+        }
+        throw new Error('Init failed with message: ' + evalResponse.message);
     }
 }

--- a/src/TemplateMarkInterpreter.ts
+++ b/src/TemplateMarkInterpreter.ts
@@ -46,6 +46,7 @@ import { CodeType, ICode } from './model-gen/org.accordproject.templatemark@0.5.
 import { GenerationOptions, joinList } from './TypeScriptRuntime';
 import { getTemplateClassDeclaration } from './utils';
 import { EvalResponse, JavaScriptEvaluator } from './JavaScriptEvaluator';
+import { CompiledUserLogic } from './UserLogic';
 
 function checkCode(code: ICode) {
     if (code.type !== CodeType.ES_2020) {
@@ -73,10 +74,13 @@ const DOCUMENT_ROOT = 'org.accordproject.commonmark@0.5.0.Document';
  * @param {*} clauseLibrary the clause library
  * @param {*} data the contract data
  * @param {string} fn the JS function (including header)
+ * @param {string} userLogicPrelude JS code (already stripped of `import`/`export`) to splice
+ *   into the formula function body, so helpers declared in the template's
+ *   `logic/logic.ts` (e.g. `monthlyPaymentFormula`) are in scope.
  * @param {GenerationOptions} options the generation options
  * @returns {object} the result of evaluating the expression against the data
  */
-async function evaluateJavaScript(clauseLibrary: object, data: TemplateData, fn: string, options?: GenerationOptions): Promise<EvalResponse> {
+async function evaluateJavaScript(clauseLibrary: object, data: TemplateData, fn: string, userLogicPrelude: string, options?: GenerationOptions): Promise<EvalResponse> {
     if (options?.disableJavaScriptEvaluation) {
         throw new Error('JavaScript evaluation is disabled.');
     }
@@ -98,8 +102,9 @@ async function evaluateJavaScript(clauseLibrary: object, data: TemplateData, fn:
     if (expression.trim().length === 0) {
         throw new Error('Empty expression');
     }
+    const codeWithPrelude = userLogicPrelude ? `${userLogicPrelude}\n${expression}` : expression;
     try {
-        const request = { code: expression, argumentNames: functionArgNames, arguments: functionArgValues };
+        const request = { code: codeWithPrelude, argumentNames: functionArgNames, arguments: functionArgValues };
         if (options?.childProcessJavaScriptEvaluation) {
             if (isBrowser) {
                 throw new Error('Child process evaluation is not supported inside web browser');
@@ -176,10 +181,11 @@ type UserCodeResult = Record<string, any>;
  * @param {*} clauseLibrary - the clause library
  * @param {*} templateMark - the TemplateMark JSON document
  * @param {*} data - the template data JSON
+ * @param {string} userLogicPrelude - JS prelude exposing helpers from logic/logic.ts
  * @param {[GenerationOptions]} options - the generation options
  * @returns {Promise<UserCodeResult>} a promise to a UserCodeResult
  */
-async function evaluateUserCode(clauseLibrary: object, templateMark: object, data: TemplateData, options?: GenerationOptions): Promise<UserCodeResult> {
+async function evaluateUserCode(clauseLibrary: object, templateMark: object, data: TemplateData, userLogicPrelude: string, options?: GenerationOptions): Promise<UserCodeResult> {
     const result: UserCodeResult = {};
     const paths = traverse(templateMark).paths();
     for (let n = 0; n < paths.length; n++) {
@@ -190,7 +196,7 @@ async function evaluateUserCode(clauseLibrary: object, templateMark: object, dat
             if (FORMULA_DEFINITION_RE.test(nodeClass)) {
                 if (context.code) {
                     checkCode(context.code);
-                    const evalResponse = await evaluateJavaScript(clauseLibrary, data, context.code.contents, options);
+                    const evalResponse = await evaluateJavaScript(clauseLibrary, data, context.code.contents, userLogicPrelude, options);
                     result[path.join('/')] = JSON.stringify(evalResponse.result);
                 }
                 else {
@@ -200,7 +206,7 @@ async function evaluateUserCode(clauseLibrary: object, templateMark: object, dat
             else if (CONDITIONAL_DEFINITION_RE.test(nodeClass) || CLAUSE_DEFINITION_RE.test(nodeClass)) {
                 if (context.condition) {
                     checkCode(context.condition);
-                    const evalResponse = await evaluateJavaScript(clauseLibrary, data, context.condition.contents, options);
+                    const evalResponse = await evaluateJavaScript(clauseLibrary, data, context.condition.contents, userLogicPrelude, options);
                     result[path.join('/')] = JSON.stringify(evalResponse.result);
                 }
             }
@@ -227,7 +233,7 @@ type OptionalBlockResult = Record<string, any[]>;
  * @param {[GenerationOptions]} options - the generation options
  * @returns {*} the AgreementMark JSON for optional blocks
  */
-async function generateOptionalBlocks(modelManager: ModelManager, clauseLibrary: object, templateMark: object, data: TemplateData, options?: GenerationOptions): Promise<OptionalBlockResult> {
+async function generateOptionalBlocks(modelManager: ModelManager, clauseLibrary: object, templateMark: object, data: TemplateData, userLogicPrelude: string, options?: GenerationOptions): Promise<OptionalBlockResult> {
     const result: OptionalBlockResult = {};
     const paths = traverse(templateMark).paths();
     for (let n = 0; n < paths.length; n++) {
@@ -251,7 +257,7 @@ async function generateOptionalBlocks(modelManager: ModelManager, clauseLibrary:
                             nodes: context.whenSome
                         };
                         // Process with the optional property value as the new data context
-                        const subResult = await generateAgreement(modelManager, clauseLibrary, whenSomeParagraph, optionalPropertyValue, options);
+                        const subResult = await generateAgreement(modelManager, clauseLibrary, whenSomeParagraph, optionalPropertyValue, userLogicPrelude, options);
                         result[thisPath.join('/')] = subResult.nodes ? subResult.nodes : [];
                     } else {
                         result[thisPath.join('/')] = [];
@@ -277,7 +283,7 @@ async function generateOptionalBlocks(modelManager: ModelManager, clauseLibrary:
  * @param {[GenerationOptions]} options - the generation options
  * @returns {*} the AgreementMark JSON for the list block
  */
-async function generateRecursiveBlocks(modelManager: ModelManager, clauseLibrary: object, templateMark: object, data: TemplateData, nodeRegExp: RegExp, childNodeClass: string, options?: GenerationOptions): Promise<RecursiveBlockResult> {
+async function generateRecursiveBlocks(modelManager: ModelManager, clauseLibrary: object, templateMark: object, data: TemplateData, nodeRegExp: RegExp, childNodeClass: string, userLogicPrelude: string, options?: GenerationOptions): Promise<RecursiveBlockResult> {
     const result: RecursiveBlockResult = {};
     const paths = traverse(templateMark).paths();
     for (let n = 0; n < paths.length; n++) {
@@ -320,7 +326,7 @@ async function generateRecursiveBlocks(modelManager: ModelManager, clauseLibrary
                         for (let n = 0; n < arrayData.length; n++) {
                             const arrayItem = arrayData[n];
                             // arrayItem is now the data for the nested generation
-                            const subResult = await generateAgreement(modelManager, clauseLibrary, itemTemplate, arrayItem, options);
+                            const subResult = await generateAgreement(modelManager, clauseLibrary, itemTemplate, arrayItem, userLogicPrelude, options);
                             // When the template had a List/Item wrapper, the processed Item's
                             // children (a Paragraph) become the children of the new output Item.
                             // Otherwise the processed block itself becomes the sole child of
@@ -351,15 +357,15 @@ async function generateRecursiveBlocks(modelManager: ModelManager, clauseLibrary
  * @param {[GenerationOptions]} options - the generation options
  * @returns {*} the AgreementMark JSON
  */
-async function generateAgreement(modelManager: ModelManager, clauseLibrary: object, templateMark: object, data: TemplateData, options?: GenerationOptions): Promise<any> {
+async function generateAgreement(modelManager: ModelManager, clauseLibrary: object, templateMark: object, data: TemplateData, userLogicPrelude: string, options?: GenerationOptions): Promise<any> {
     const introspector = new Introspector(modelManager);
     // evaluate all the user code (async)
-    const userCodeResults = await evaluateUserCode(clauseLibrary, templateMark, data, options);
+    const userCodeResults = await evaluateUserCode(clauseLibrary, templateMark, data, userLogicPrelude, options);
     // evaluate all recursive blocks (async)
-    const listBlockResults = await generateRecursiveBlocks(modelManager, clauseLibrary, templateMark, data, LISTBLOCK_DEFINITION_RE, `${CommonMarkModel.NAMESPACE}.Item`, options);
-    const foreachBlockResults = await generateRecursiveBlocks(modelManager, clauseLibrary, templateMark, data, FOREACH_DEFINITION_RE, `${CommonMarkModel.NAMESPACE}.Paragraph`, options);
+    const listBlockResults = await generateRecursiveBlocks(modelManager, clauseLibrary, templateMark, data, LISTBLOCK_DEFINITION_RE, `${CommonMarkModel.NAMESPACE}.Item`, userLogicPrelude, options);
+    const foreachBlockResults = await generateRecursiveBlocks(modelManager, clauseLibrary, templateMark, data, FOREACH_DEFINITION_RE, `${CommonMarkModel.NAMESPACE}.Paragraph`, userLogicPrelude, options);
     // evaluate all optional blocks (async)
-    const optionalBlockResults = await generateOptionalBlocks(modelManager, clauseLibrary, templateMark, data, options);
+    const optionalBlockResults = await generateOptionalBlocks(modelManager, clauseLibrary, templateMark, data, userLogicPrelude, options);
     // traverse the templatemark, creating an output agreementmark tree
     return traverse(templateMark).map(function (context: any) {
         let stopHere = false;
@@ -608,11 +614,13 @@ export class TemplateMarkInterpreter {
     modelManager: ModelManager;
     templateClass: ClassDeclaration;
     clauseLibrary: object;
+    userLogic?: CompiledUserLogic;
 
-    constructor(modelManager: ModelManager, clauseLibrary: object, templateConceptFqn?: string) {
+    constructor(modelManager: ModelManager, clauseLibrary: object, templateConceptFqn?: string, userLogic?: CompiledUserLogic) {
         this.modelManager = modelManager;
         this.clauseLibrary = clauseLibrary;
         this.templateClass = getTemplateClassDeclaration(this.modelManager, templateConceptFqn);
+        this.userLogic = userLogic;
     }
 
     /**
@@ -718,7 +726,7 @@ export class TemplateMarkInterpreter {
         if(firstChild.name !== 'top') {
             throw new Error('First child is not named "top"!');
         }
-        const compiler = new TemplateMarkToJavaScriptCompiler(this.modelManager, templateConcept);
+        const compiler = new TemplateMarkToJavaScriptCompiler(this.modelManager, templateConcept, this.userLogic?.symbols ?? []);
         await compiler.initialize();
         return compiler.compile(templateMark);
     }
@@ -748,7 +756,8 @@ export class TemplateMarkInterpreter {
         const typedTemplateMark = this.checkTypes(templateMark);
         const jsTemplateMark = await this.compileTypeScriptToJavaScript(typedTemplateMark);
         // console.log('Compiled JS: ' + JSON.stringify(jsTemplateMark, null, 2));
-        const ciceroMark = await generateAgreement(this.modelManager, this.clauseLibrary, jsTemplateMark, data, options);
+        const userLogicPrelude = this.userLogic?.prelude ?? '';
+        const ciceroMark = await generateAgreement(this.modelManager, this.clauseLibrary, jsTemplateMark, data, userLogicPrelude, options);
         // console.log('Generated AgreementMark');
         return this.validateCiceroMark(ciceroMark);
     }

--- a/src/TemplateMarkToJavaScriptCompiler.ts
+++ b/src/TemplateMarkToJavaScriptCompiler.ts
@@ -49,9 +49,9 @@ export class TemplateMarkToJavaScriptCompiler {
     compiler: TypeScriptToJavaScriptCompiler;
     templateClass: ClassDeclaration;
 
-    constructor(modelManager: ModelManager, templateConceptFqn?: string) {
+    constructor(modelManager: ModelManager, templateConceptFqn?: string, userLogicSymbols: string[] = []) {
         this.modelManager = modelManager;
-        this.compiler = new TypeScriptToJavaScriptCompiler(modelManager,templateConceptFqn);
+        this.compiler = new TypeScriptToJavaScriptCompiler(modelManager,templateConceptFqn,userLogicSymbols);
         this.templateClass = getTemplateClassDeclaration(modelManager,templateConceptFqn);
     }
 

--- a/src/TypeScriptCompilationContext.ts
+++ b/src/TypeScriptCompilationContext.ts
@@ -27,10 +27,12 @@ export class TypeScriptCompilationContext {
 
     modelManager:ModelManager;
     templateClass:ClassDeclaration;
+    userLogicSymbols: string[];
 
-    constructor(modelManager:ModelManager,templateConceptFqn?: string) {
+    constructor(modelManager:ModelManager,templateConceptFqn?: string, userLogicSymbols: string[] = []) {
         this.modelManager = modelManager;
         this.templateClass = getTemplateClassDeclaration(this.modelManager, templateConceptFqn);
+        this.userLogicSymbols = userLogicSymbols;
     }
 
     getTypeScriptFiles() : Record<string,string> {
@@ -73,6 +75,16 @@ type GenerationOptions = {
     locale?:string
 }
 `;
+        // Ambient declarations for top-level symbols in the template's
+        // logic/logic.ts so formula expressions like {{% helperFn(...) %}}
+        // type-check. At runtime the formula evaluator prepends the
+        // compiled logic JS, so the same symbols resolve to real values.
+        if (this.userLogicSymbols.length > 0) {
+            result += '\n';
+            this.userLogicSymbols.forEach(name => {
+                result += `declare const ${name}: any;\n`;
+            });
+        }
         return result;
     }
 }

--- a/src/TypeScriptToJavaScriptCompiler.ts
+++ b/src/TypeScriptToJavaScriptCompiler.ts
@@ -84,8 +84,8 @@ export class TypeScriptToJavaScriptCompiler {
     ts: any;
     typescriptUrl: string;
 
-    constructor(modelManager: ModelManager, templateConceptFqn?: string) {
-        this.context = new TypeScriptCompilationContext(modelManager, templateConceptFqn).getCompilationContext();
+    constructor(modelManager: ModelManager, templateConceptFqn?: string, userLogicSymbols: string[] = []) {
+        this.context = new TypeScriptCompilationContext(modelManager, templateConceptFqn, userLogicSymbols).getCompilationContext();
         this.typescriptUrl = TYPESCRIPT_URL;
     }
 

--- a/src/UserLogic.ts
+++ b/src/UserLogic.ts
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModelManager } from '@accordproject/concerto-core';
+import { TypeScriptToJavaScriptCompiler } from './TypeScriptToJavaScriptCompiler';
+import { SMART_LEGAL_CONTRACT_BASE64 } from './runtime/declarations';
+
+/**
+ * The result of compiling the user-authored logic.ts that ships
+ * with a template archive. Used by both
+ * TemplateArchiveProcessor.trigger/init (to execute the logic class)
+ * and TemplateArchiveProcessor.draft (to expose helper symbols to
+ * formula expressions like {{% helperFn(...) %}}).
+ */
+export type CompiledUserLogic = {
+    /** Raw TypeScript source from logic/logic.ts */
+    source: string;
+    /** Compiled JavaScript (ESM) output */
+    compiledJs: string;
+    /**
+     * Top-level identifiers (functions, classes, const/let/var bindings)
+     * declared by the compiled JS. Used to populate `declare const X: any`
+     * stubs when compiling inline formulas, so user helper functions
+     * type-check.
+     */
+    symbols: string[];
+    /**
+     * `compiledJs` with `import`/`export` statements stripped so it can be
+     * spliced into a formula function body as a runtime prelude.
+     */
+    prelude: string;
+};
+
+/**
+ * Compiles the template's logic/logic.ts to JavaScript. Mirrors what
+ * TemplateArchiveProcessor.trigger() has always done, but as a shared
+ * helper so draft() can also load logic helpers (see issue #147).
+ */
+export async function compileUserLogic(
+    modelManager: ModelManager,
+    templateConceptFqn: string,
+    source: string,
+): Promise<CompiledUserLogic> {
+    const compiler = new TypeScriptToJavaScriptCompiler(modelManager, templateConceptFqn);
+    await compiler.initialize();
+    const code = `${Buffer.from(SMART_LEGAL_CONTRACT_BASE64, 'base64').toString()}
+${source}`;
+    const result = compiler.compile(code);
+    const compiledJs = result.code || '';
+    const prelude = stripModuleSyntax(compiledJs);
+    const symbols = extractTopLevelSymbols(prelude);
+    return { source, compiledJs, symbols, prelude };
+}
+
+/**
+ * Removes top-level `import` statements and the `export` keyword from
+ * JS source so that the remaining declarations can be evaluated inside
+ * a function body via `new Function(...)`. The compiled output of
+ * logic.ts is an ES module; both `import` and `export` are syntax
+ * errors inside a `new Function` body.
+ */
+export function stripModuleSyntax(js: string): string {
+    let result = js;
+    // Drop import statements (single or multi-line).
+    result = result.replace(/^[ \t]*import[\s\S]*?(?:;|\n)/gm, '');
+    // Drop `export default <expr>;` lines entirely.
+    result = result.replace(/^[ \t]*export\s+default\s+[^;\n]*;?\s*$/gm, '');
+    // Strip a leading `export ` keyword from declarations
+    // (`export function`, `export class`, `export const`, ...).
+    result = result.replace(/^[ \t]*export\s+(?=(?:async\s+)?(?:abstract\s+)?(?:function|class|const|let|var|interface|type|enum)\b)/gm, '');
+    return result;
+}
+
+/**
+ * Extracts top-level identifier names declared in the JS source.
+ * Heuristic, regex-based — good enough for the common case of helper
+ * functions and constants in a template's logic.ts.
+ */
+export function extractTopLevelSymbols(js: string): string[] {
+    const names = new Set<string>();
+    const patterns = [
+        /^\s*(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)/gm,
+        /^\s*(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/gm,
+        /^\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm,
+    ];
+    for (const re of patterns) {
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(js)) !== null) {
+            names.add(m[1]);
+        }
+    }
+    return Array.from(names);
+}

--- a/test/TemplateArchiveProcessor.test.ts
+++ b/test/TemplateArchiveProcessor.test.ts
@@ -57,6 +57,33 @@ describe('template archive processor', () => {
         expect(payload.count).toBe(0);
     });
 
+    test('should draft a template whose formula calls a helper from logic/logic.ts (#147)', async () => {
+        const template = await Template.fromDirectory('test/archives/formula-uses-logic-helper', {offline: true});
+        const templateArchiveProcessor = new TemplateArchiveProcessor(template);
+        const data = {
+            "$class": "io.clause.latedeliveryandpenalty@0.1.0.TemplateModel",
+            "forceMajeure": true,
+            "penaltyDuration": {
+                "$class": "org.accordproject.time@0.3.0.Duration",
+                "amount": 2,
+                "unit": "days"
+            },
+            "penaltyPercentage": 10.5,
+            "capPercentage": 55,
+            "termination": {
+                "$class": "org.accordproject.time@0.3.0.Duration",
+                "amount": 15,
+                "unit": "days"
+            },
+            "fractionalPart": "days",
+            "clauseId": "c88e5ed7-c3e0-4249-a99c-ce9278684ac8",
+            "$identifier": "c88e5ed7-c3e0-4249-a99c-ce9278684ac8"
+        };
+        const result = await templateArchiveProcessor.draft(data, 'markdown', {});
+        // calc(10.5) === 10.5 * 2.5 === 26.25
+        expect(result).toContain('penalty multiplier of 26.25');
+    });
+
     test('should trigger a template', async () => {
         const template = await Template.fromDirectory('test/archives/latedeliveryandpenalty-typescript', {offline: true});
         const templateArchiveProcessor = new TemplateArchiveProcessor(template);

--- a/test/archives/formula-uses-logic-helper/README.md
+++ b/test/archives/formula-uses-logic-helper/README.md
@@ -1,0 +1,7 @@
+
+# Clause Template: Late Delivery And Penalty
+
+## Sample
+
+Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 2 days of delay penalty amounting to 10.5% of total value of the Equipment whose delivery has been delayed. Any fractional part of a day is to be considered a full day. The total amount of penalty shall not, however, exceed 55% of the total value of the Equipment involved in late delivery. If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.
+

--- a/test/archives/formula-uses-logic-helper/logic/README.md
+++ b/test/archives/formula-uses-logic-helper/logic/README.md
@@ -1,0 +1,25 @@
+# Introduction
+
+This is a sample Accord Project template that includes logic for the template written in TypeScript.
+
+# Template Model
+
+The data model for the template defines the structure of the data for the contract (a "clause" in this case).
+The template concept has the `@template` annotation.
+
+The template model also defines the request and response types for the template logic.
+
+The template model may optionally also define a state type for the template logic, for templates that support state.
+
+# Template Logic
+
+To write your template logic you should first generate the TypeScript source code for the template
+using the `concerto compile --model ./model/model.cto --target typescript --output logic/generated` CLI command.
+
+You can then define and export the template logic class, which should implement the `TemplateLogic` interface,
+implementing the trigger method and optionally the init method.
+
+## Current Limitations
+
+1. All template logic must be written in TypeScript and in a single file called logic.ts within the logic folder of the template
+2. You cannot import third-party modules into your template logic

--- a/test/archives/formula-uses-logic-helper/logic/generated/concerto.decorator@1.0.0.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/concerto.decorator@1.0.0.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type*/
+// Generated code for namespace: concerto.decorator@1.0.0
+
+// imports
+import {IConcept} from './concerto@1.0.0';
+
+// interfaces
+export interface IDecorator extends IConcept {
+}
+
+export interface IDotNetNamespace extends IDecorator {
+   namespace: string;
+}

--- a/test/archives/formula-uses-logic-helper/logic/generated/concerto.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/concerto.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type*/
+// Generated code for namespace: concerto
+
+// imports
+
+// interfaces
+export interface IConcept {
+   $class: string;
+}
+
+export interface IAsset extends IConcept {
+   $identifier: string;
+}
+
+export interface IParticipant extends IConcept {
+   $identifier: string;
+}
+
+export interface ITransaction extends IConcept {
+}
+
+export interface IEvent extends IConcept {
+}

--- a/test/archives/formula-uses-logic-helper/logic/generated/concerto@1.0.0.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/concerto@1.0.0.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-unused-vars*/
+// Generated code for namespace: concerto@1.0.0
+
+// imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	ILateDeliveryAndPenaltyState
+} from './io.clause.latedeliveryandpenalty@0.1.0';
+import type {
+	Month,
+	Day,
+	TemporalUnit,
+	IDuration,
+	PeriodUnit,
+	IPeriod
+} from './org.accordproject.time@0.3.0';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IContract,
+	IClause
+} from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IRequest,
+	IResponse
+} from './org.accordproject.runtime@0.2.0';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	ILateDeliveryAndPenaltyEvent
+} from './io.clause.latedeliveryandpenalty@0.1.0';
+import type {
+	IObligation
+} from './org.accordproject.runtime@0.2.0';
+
+// interfaces
+export interface IConcept {
+   $class: string;
+}
+
+export type ConceptUnion = ILateDeliveryAndPenaltyState |
+IDuration |
+IPeriod;
+
+export interface IAsset extends IConcept {
+   $identifier: string;
+}
+
+export type AssetUnion = IContract |
+IClause |
+IState;
+
+export interface IParticipant extends IConcept {
+   $identifier: string;
+}
+
+export interface ITransaction extends IConcept {
+   $timestamp: Date;
+}
+
+export type TransactionUnion = IRequest |
+IResponse;
+
+export interface IEvent extends IConcept {
+   $timestamp: Date;
+}
+
+export type EventUnion = ILateDeliveryAndPenaltyEvent |
+IObligation;

--- a/test/archives/formula-uses-logic-helper/logic/generated/io.clause.latedeliveryandpenalty@0.1.0.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/io.clause.latedeliveryandpenalty@0.1.0.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type*/
+// Generated code for namespace: io.clause.latedeliveryandpenalty@0.1.0
+
+// imports
+import {IDuration,TemporalUnit} from './org.accordproject.time@0.3.0';
+import {IClause} from './org.accordproject.contract@0.2.0';
+import {IRequest,IResponse} from './org.accordproject.runtime@0.2.0';
+import {IEvent,IConcept} from './concerto@1.0.0';
+
+// interfaces
+export interface ITemplateModel extends IClause {
+   forceMajeure: boolean;
+   penaltyDuration: IDuration;
+   penaltyPercentage: number;
+   capPercentage: number;
+   termination: IDuration;
+   fractionalPart: TemporalUnit;
+}
+
+export interface ILateDeliveryAndPenaltyRequest extends IRequest {
+   forceMajeure: boolean;
+   agreedDelivery: Date;
+   deliveredAt?: Date;
+   goodsValue: number;
+}
+
+export interface ILateDeliveryAndPenaltyResponse extends IResponse {
+   penalty: number;
+   buyerMayTerminate: boolean;
+}
+
+export interface ILateDeliveryAndPenaltyEvent extends IEvent {
+   penaltyCalculated: boolean;
+}
+
+export interface ILateDeliveryAndPenaltyState extends IConcept {
+   $identifier: string;
+   count: number;
+}

--- a/test/archives/formula-uses-logic-helper/logic/generated/org.accordproject.contract@0.2.0.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/org.accordproject.contract@0.2.0.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type*/
+// Generated code for namespace: org.accordproject.contract@0.2.0
+
+// imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	ITemplateModel
+} from './io.clause.latedeliveryandpenalty@0.1.0';
+import {IAsset} from './concerto@1.0.0';
+
+// interfaces
+export interface IContract extends IAsset {
+   contractId: string;
+}
+
+export interface IClause extends IAsset {
+   clauseId: string;
+}
+
+export type ClauseUnion = ITemplateModel;

--- a/test/archives/formula-uses-logic-helper/logic/generated/org.accordproject.runtime@0.2.0.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/org.accordproject.runtime@0.2.0.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type*/
+// Generated code for namespace: org.accordproject.runtime@0.2.0
+
+// imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	ILateDeliveryAndPenaltyRequest
+} from './io.clause.latedeliveryandpenalty@0.1.0';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	ILateDeliveryAndPenaltyResponse
+} from './io.clause.latedeliveryandpenalty@0.1.0';
+import {IContract} from './org.accordproject.contract@0.2.0';
+import {ITransaction,IEvent,IParticipant,IAsset} from './concerto@1.0.0';
+
+// interfaces
+export interface IRequest extends ITransaction {
+}
+
+export type RequestUnion = ILateDeliveryAndPenaltyRequest;
+
+export interface IResponse extends ITransaction {
+}
+
+export type ResponseUnion = ILateDeliveryAndPenaltyResponse;
+
+export interface IObligation extends IEvent {
+   $identifier: string;
+   contract: IContract;
+   promisor?: IParticipant;
+   promisee?: IParticipant;
+   deadline?: Date;
+}
+
+export interface IState extends IAsset {
+}

--- a/test/archives/formula-uses-logic-helper/logic/generated/org.accordproject.time@0.3.0.ts
+++ b/test/archives/formula-uses-logic-helper/logic/generated/org.accordproject.time@0.3.0.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type*/
+// Generated code for namespace: org.accordproject.time@0.3.0
+
+// imports
+import {IConcept} from './concerto@1.0.0';
+
+// interfaces
+export enum Month {
+   January = 'January',
+   February = 'February',
+   March = 'March',
+   April = 'April',
+   May = 'May',
+   June = 'June',
+   July = 'July',
+   August = 'August',
+   September = 'September',
+   October = 'October',
+   November = 'November',
+   December = 'December',
+}
+
+export enum Day {
+   Monday = 'Monday',
+   Tuesday = 'Tuesday',
+   Wednesday = 'Wednesday',
+   Thursday = 'Thursday',
+   Friday = 'Friday',
+   Saturday = 'Saturday',
+   Sunday = 'Sunday',
+}
+
+export enum TemporalUnit {
+   seconds = 'seconds',
+   minutes = 'minutes',
+   hours = 'hours',
+   days = 'days',
+   weeks = 'weeks',
+}
+
+export interface IDuration extends IConcept {
+   amount: number;
+   unit: TemporalUnit;
+}
+
+export enum PeriodUnit {
+   days = 'days',
+   weeks = 'weeks',
+   months = 'months',
+   quarters = 'quarters',
+   years = 'years',
+}
+
+export interface IPeriod extends IConcept {
+   amount: number;
+   unit: PeriodUnit;
+}

--- a/test/archives/formula-uses-logic-helper/logic/logic.ts
+++ b/test/archives/formula-uses-logic-helper/logic/logic.ts
@@ -1,0 +1,54 @@
+// import { EngineResponse, TemplateLogic } from "../../../../src/slc/SmartLegalContract";
+import { ILateDeliveryAndPenaltyState, ILateDeliveryAndPenaltyRequest, ILateDeliveryAndPenaltyResponse, ILateDeliveryAndPenaltyEvent, ITemplateModel } from "./generated/io.clause.latedeliveryandpenalty@0.1.0";
+// demo utility function
+function calc(input: number) : number {
+    const result = input * 2.5;
+    return result;
+}
+
+// @ts-expect-error EngineResponse is imported by the runtime
+interface LateDeliveryContractResponse extends EngineResponse<ILateDeliveryAndPenaltyState> {
+    result: ILateDeliveryAndPenaltyResponse;
+    state: object;
+    events: object[];
+}
+
+// sample contract logic that is stateless
+// - no init method
+// @ts-expect-error TemplateLogic is imported by the runtime
+class LateDeliveryLogic extends TemplateLogic<ITemplateModel, ILateDeliveryAndPenaltyState>  {
+    // @ts-expect-error InitResponse is imported by the runtime
+    async init(data: ITemplateModel) : Promise<InitResponse<ILateDeliveryAndPenaltyState>> {
+        return {
+            state: {
+                $class: 'io.clause.latedeliveryandpenalty@0.1.0.LateDeliveryAndPenaltyState',
+                $identifier: data.$identifier,
+                count: 0,
+            }
+        }
+    }
+    async trigger(data: ITemplateModel, request:ILateDeliveryAndPenaltyRequest, state:ILateDeliveryAndPenaltyState) : Promise<LateDeliveryContractResponse> {
+        const event:ILateDeliveryAndPenaltyEvent = {
+                $class: 'io.clause.latedeliveryandpenalty@0.1.0.LateDeliveryAndPenaltyEvent',
+                $timestamp: new Date(),
+                penaltyCalculated: true
+            };
+        const newState:ILateDeliveryAndPenaltyState = {
+            $class: 'io.clause.latedeliveryandpenalty@0.1.0.LateDeliveryAndPenaltyState',
+            $identifier: state.$identifier,
+            count: state.count + 1,
+        }
+        return {
+            result: {
+                penalty: data.penaltyPercentage * calc(request.goodsValue),
+                buyerMayTerminate: true,
+                $timestamp: new Date(),
+                $class: 'io.clause.latedeliveryandpenalty@0.1.0.LateDeliveryAndPenaltyResponse'
+            },
+            events: [event],
+            state: newState
+        }
+    }
+}
+
+export default LateDeliveryLogic;

--- a/test/archives/formula-uses-logic-helper/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/test/archives/formula-uses-logic-helper/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.contract@0.2.0
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset Contract identified by contractId {
+  o String contractId
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset Clause identified by clauseId {
+  o String clauseId
+}

--- a/test/archives/formula-uses-logic-helper/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/test/archives/formula-uses-logic-helper/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.runtime@0.2.0
+
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+
+/**
+ * Runtime API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {
+}
+
+/* A response is a transaction */
+transaction Response {
+}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation identified {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> Contract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional
+
+  /* The party that receives the performance */
+  --> Participant promisee optional
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset State {
+}

--- a/test/archives/formula-uses-logic-helper/model/@models.accordproject.org.time@0.3.0.cto
+++ b/test/archives/formula-uses-logic-helper/model/@models.accordproject.org.time@0.3.0.cto
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+concerto version "^3.0.0"
+
+namespace org.accordproject.time@0.3.0
+
+/**
+ * Months of the year
+ */
+enum Month {
+  o January
+  o February
+  o March
+  o April
+  o May
+  o June
+  o July
+  o August
+  o September
+  o October
+  o November
+  o December
+}
+
+/**
+ * Days of the week
+ */
+enum Day {
+  o Monday
+  o Tuesday
+  o Wednesday
+  o Thursday
+  o Friday
+  o Saturday
+  o Sunday
+}
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}
+
+/**
+ * Units for a time period.
+ */
+enum PeriodUnit {
+  o days
+  o weeks
+  o months
+  o quarters
+  o years
+}
+
+/**
+ * A time period. For example, 2 months.
+ */
+concept Period {
+  o Long amount
+  o PeriodUnit unit
+}

--- a/test/archives/formula-uses-logic-helper/model/model.cto
+++ b/test/archives/formula-uses-logic-helper/model/model.cto
@@ -1,0 +1,99 @@
+namespace io.clause.latedeliveryandpenalty@0.1.0
+
+import org.accordproject.time@0.3.0.{Duration, TemporalUnit} from https://models.accordproject.org/time@0.3.0.cto
+
+import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+
+/**
+ * Defines the data model for the LateDeliveryAndPenalty template.
+ * This defines the structure of the abstract syntax tree that the parser for the template
+ * must generate from input source text.
+ */
+@template
+asset TemplateModel extends Clause {
+  /**
+   * Does the clause include a force majeure provision?
+   */
+  o Boolean forceMajeure
+
+  /**
+   * For every penaltyDuration that the goods are late
+   */
+  o Duration penaltyDuration
+
+  /**
+   * Seller pays the buyer penaltyPercentage % of the value of the goods
+   */
+  o Double penaltyPercentage
+
+  /**
+   * Up to capPercentage % of the value of the goods
+   */
+  o Double capPercentage
+
+  /**
+   * If the goods are >= termination late then the buyer may terminate the contract
+   */
+  o Duration termination
+
+  /**
+   * Fractional part of a ... is considered a whole ...
+   */
+  o TemporalUnit fractionalPart
+}
+
+/**
+ * Defines the input data required by the template
+ */
+transaction LateDeliveryAndPenaltyRequest extends Request {
+
+  /**
+   * Are we in a force majeure situation?
+   */
+  o Boolean forceMajeure
+
+  /**
+   * What was the agreed delivery date for the goods?
+   */
+  o DateTime agreedDelivery
+
+  /**
+   * If the goods have been delivered, when where they delivered?
+   */
+  o DateTime deliveredAt optional
+
+  /**
+   * What is the value of the goods?
+   */
+  o Double goodsValue
+}
+
+/**
+ * Defines the output data for the template
+ */
+transaction LateDeliveryAndPenaltyResponse extends Response {
+  /**
+   * The penalty to be paid by the seller
+   */
+  o Double penalty
+
+  /**
+   * Whether the buyer may terminate the contract
+   */
+  o Boolean buyerMayTerminate
+}
+
+/**
+ * Define an event that is emitted by the template
+ */
+event LateDeliveryAndPenaltyEvent {
+  o Boolean penaltyCalculated
+}
+
+/**
+ * Defines the state of the template
+ */
+concept LateDeliveryAndPenaltyState identified {
+  o Integer count
+}

--- a/test/archives/formula-uses-logic-helper/package.json
+++ b/test/archives/formula-uses-logic-helper/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "formula-uses-logic-helper",
+    "version": "0.0.1",
+    "description": "Fixture for issue #147: a clause whose grammar contains a formula that calls a helper function defined in logic/logic.ts.",
+    "accordproject": {
+        "runtime": "typescript",
+        "template": "clause",
+        "cicero": "^0.26.0"
+    }
+}

--- a/test/archives/formula-uses-logic-helper/request.json
+++ b/test/archives/formula-uses-logic-helper/request.json
@@ -1,0 +1,7 @@
+{
+    "$class": "io.clause.latedeliveryandpenalty@0.1.0.LateDeliveryAndPenaltyRequest",
+    "forceMajeure": false,
+    "agreedDelivery": "December 17, 2017 03:24:00",
+    "deliveredAt": null,
+    "goodsValue": 200.00
+}

--- a/test/archives/formula-uses-logic-helper/text/grammar.tem.md
+++ b/test/archives/formula-uses-logic-helper/text/grammar.tem.md
@@ -1,0 +1,7 @@
+Late Delivery and Penalty
+----
+In case of delayed delivery{{#if forceMajeure}} except for Force Majeure cases,{{/if}} the Seller shall pay to the Buyer for every {{penaltyDuration}} of delay penalty amounting to {{penaltyPercentage}}% of the total value of the Equipment whose delivery has been delayed. With a penalty multiplier of {{% return calc(penaltyPercentage); %}}.
+
+1. Any fractional part of a {{fractionalPart}} is to be considered a full {{fractionalPart}}.
+1. The total amount of penalty shall not however, exceed {{capPercentage}}% of the total value of the Equipment involved in late delivery.
+1. If the delay is more than {{termination}}, the Buyer is entitled to terminate this Contract.


### PR DESCRIPTION
## Summary

Fixes #147.

`TemplateArchiveProcessor.draft()` was compiling each inline formula
(`{{% expr %}}`) with a TypeScript context that did **not** include
the template's user code from `logic/logic.ts`. As a result, helper
functions like `monthlyPaymentFormula(...)` produced
`Cannot find name 'monthlyPaymentFormula'` (TS2304) and drafting failed
on otherwise valid templates (repro: cicero-template-library PR #484
`src/fixed-interests`).

`trigger()` and `init()` were already loading `logic/logic.ts` via
`TypeScriptToJavaScriptCompiler`. They just didn't share that work with
`draft()`.

## Fix

- Extracted the existing trigger/init compilation into a shared helper
  `compileUserLogic` (`src/UserLogic.ts`). It returns the compiled JS
  along with the top-level identifiers (`function`, `class`,
  `const`/`let`/`var`) it declares and a copy of that JS with `import`/
  `export` syntax stripped so it can be spliced into a `new Function`
  body.
- `TypeScriptCompilationContext` now emits `declare const <name>: any;`
  for each declared identifier, so user helpers type-check inside
  formula expressions.
- `TemplateMarkInterpreter` accepts a `CompiledUserLogic` and threads
  the runtime prelude through to the JS formula evaluator, so the same
  identifiers are real values at evaluation time.
- `TemplateArchiveProcessor`:
  - `draft()` now calls `compileLogic()` and passes the result into the
    interpreter.
  - `trigger()` and `init()` were refactored to call the same
    `compileLogic()` helper, so all three code paths now load logic via
    the same path.

## Repro / test

Added `test/archives/formula-uses-logic-helper`: a minimal template
fixture whose grammar contains `{{% return calc(penaltyPercentage); %}}`
where `calc` is a helper function declared in `logic/logic.ts`.

The new test in `test/TemplateArchiveProcessor.test.ts`:
- Fails on `main` with `TS2304: Cannot find name 'calc'.`
- Passes with this change (`calc(10.5) === 26.25`).

## Test plan

- [x] Reproduce TS2304 with a minimal fixture before the fix.
- [x] New unit test passes with the fix applied.
- [x] Existing `should draft a template` still passes (template with
      logic.ts but no helper-calling formula).
- [x] Existing `should trigger a template` / `should init a template`
      still pass after refactor to shared helper.
- [x] `npx eslint src/ test/` — no new errors.
- [ ] CI to run the full suite. (Network-restricted local environment
      blocks `models.accordproject.org`, so some unrelated tests fail
      locally on `main` too.)


---
_Generated by [Claude Code](https://claude.ai/code/session_015oW4bkAfhetsTnVNtCQmqz)_