### PR TITLE
fix(publish): publish on Node 22; tag.js off deprecated set-output

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,10 +25,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/scripts/tag.js
+++ b/scripts/tag.js
@@ -15,6 +15,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const semver = require('semver');
 const targetVersion = process.argv[2];
 
@@ -26,4 +27,10 @@ if (!semver.valid(targetVersion)) {
 const prerelease = semver.prerelease(targetVersion);
 const tag = prerelease ? 'unstable' : 'latest';
 
-console.log(`::set-output name=tag::--tag=${tag}`);
+const output = `--tag=${tag}`;
+if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=${output}
+`);
+} else {
+    console.log(output);
+}


### PR DESCRIPTION
Prep before cutting the v4.0.0 release.

- npm-publish.yml builds on **Node 22** (the build/deps now require >=22; markdown-transform / cicero-core 1.0.1)
- migrate `scripts/tag.js` from the deprecated `::set-output` to `$GITHUB_OUTPUT`

Note: the release should be **v4.0.0** (breaking: lib/ entry, cicero-core 1.0.0+, dropped ESM). The publish builds lib/ + umd/ via `prepublishOnly: build:dist`.

 Generated with [Claude Code](https://claude.com/claude-code)