### PR TITLE
fix: throw Error instead of raw array for TypeScript compilation failures

### DIFF
--- a/src/TemplateMarkToJavaScriptCompiler.ts
+++ b/src/TemplateMarkToJavaScriptCompiler.ts
@@ -105,7 +105,13 @@ export class TemplateMarkToJavaScriptCompiler {
             return compiled;
         }
         else {
-            throw errors;
+            const message = errors.map(err => {
+                const tsErrors = err.errors.map(tsErr => 
+                    `  - [Line ${tsErr.line}, Col ${tsErr.character}]: ${tsErr.renderedMessage}`
+                ).join('\n');
+                return `Node ID: ${err.nodeId}\n${tsErrors}`;
+            }).join('\n\n');
+            throw new Error(`Template compilation failed:\n${message}`);
         }
     }
 }


### PR DESCRIPTION
Resolves #128

**Problem:**
When a template formula contained invalid TypeScript, `TemplateMarkToJavaScriptCompiler.compile()` threw a raw `Array<CompilerError>`. This meant that any caller catching this error received `[object Object]` without a `.message` or a stack trace, making the rich error information collected by Twoslash inaccessible.

**Solution:**
Wrapped the raw `errors` array into a proper standard JavaScript `Error` object. The new error message groups the compilation failures by their `nodeId` and maps out each individual issue with its corresponding line and column number, making the failures much easier for users to debug.
