### PR TITLE
fix: throw Error instead of raw array for TypeScript compilation fail…

### DIFF
--- a/src/TemplateMarkToJavaScriptCompiler.ts
+++ b/src/TemplateMarkToJavaScriptCompiler.ts
@@ -105,7 +105,13 @@ export class TemplateMarkToJavaScriptCompiler {
             return compiled;
         }
         else {
-            throw errors;
+            const messages = errors.map(e => {
+                const tsErrors = e.errors.map((tsErr: any) => {
+                    return `  - ${tsErr.renderedMessage} (line: ${tsErr.line}, column: ${tsErr.character})`;
+                }).join('\n');
+                return `Node ID: ${e.nodeId}\n${tsErrors}`;
+            }).join('\n\n');
+            throw new Error(`Template compilation failed:\n${messages}`);
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue in `TemplateMarkToJavaScriptCompiler.compile()` where a raw `Array<CompilerError>` was being thrown instead of a standard `Error` object when a template formula contained invalid TypeScript. 

Previously, any caller catching this compilation failure would receive `[object Object]` without a `.message` property or a stack trace, making the rich error information (collected by twoslash) completely inaccessible.

## Changes Made
- Wrapped the compilation errors array in a standard `Error` object.
- Formatted the error `.message` to be human-readable, exposing the exact:
  - Node ID
  - Error description (rendered message)
  - Line number
  - Column number (character)

## Related Issues
Fixes #128 

*(Note: `TemplateArchiveProcessor` has a similar issue where `result.errors` is not checked after compilation, which will be addressed in a follow-up issue).*
