### PR TITLE
feat: add strict validation for TemplateLogic subclass (#163)

### DIFF
--- a/src/TemplateArchiveProcessor.ts
+++ b/src/TemplateArchiveProcessor.ts
@@ -102,39 +102,55 @@ export class TemplateArchiveProcessor {
     /**
      * Compile the logic of a template
      * @param {boolean} [enableCompiledLogicCache] - whether to cache the compiled logic for future use
+     * @param {boolean} [requireTemplateLogic] - whether to throw if a TemplateLogic class is not found
      * @returns {Promise<Record<string, TwoSlashReturn>>} the compiled code for each typescript file
      */
-    async compileLogic(enableCompiledLogicCache: boolean = false): Promise<Record<string, TwoSlashReturn>> {
+    async compileLogic(enableCompiledLogicCache: boolean = false, requireTemplateLogic: boolean = false): Promise<Record<string, TwoSlashReturn>> {
+        let compiledCode: Record<string, TwoSlashReturn> = {};
         if (enableCompiledLogicCache && this.compiledLogicCache) {
-            return this.compiledLogicCache;
-        }
-
-        const logicManager = this.template.getLogicManager();
-        if (logicManager.getLanguage() === 'typescript') {
-            const compiledCode: Record<string, TwoSlashReturn> = {};
-            const tsFiles: Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
-            for (let n = 0; n < tsFiles.length; n++) {
-                const tsFile = tsFiles[n];
-
-                const compiler = new TypeScriptToJavaScriptCompiler(this.template.getModelManager(),
-                    this.template.getTemplateModel().getFullyQualifiedName());
-
-                await compiler.initialize();
-
-                // add the runtime type definitions to all ts files
-                const code = `${Buffer.from(SMART_LEGAL_CONTRACT_BASE64, 'base64').toString()}
-                ${tsFile.getContents()}`;
-
-                const result = compiler.compile(code);
-                compiledCode[tsFile.getIdentifier()] = result;
-            }
-            if (enableCompiledLogicCache) {
-                this.compiledLogicCache = compiledCode;
-            }
-            return compiledCode;
+            compiledCode = this.compiledLogicCache;
         } else {
-            throw new Error('Only TypeScript is supported at this time');
+            const logicManager = this.template.getLogicManager();
+            if (logicManager.getLanguage() === 'typescript') {
+                const tsFiles: Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
+                for (let n = 0; n < tsFiles.length; n++) {
+                    const tsFile = tsFiles[n];
+
+                    const compiler = new TypeScriptToJavaScriptCompiler(this.template.getModelManager(),
+                        this.template.getTemplateModel().getFullyQualifiedName());
+
+                    await compiler.initialize();
+
+                    // add the runtime type definitions to all ts files
+                    const code = `${Buffer.from(SMART_LEGAL_CONTRACT_BASE64, 'base64').toString()}
+                    ${tsFile.getContents()}`;
+
+                    const result = compiler.compile(code);
+                    compiledCode[tsFile.getIdentifier()] = result;
+                }
+                if (enableCompiledLogicCache) {
+                    this.compiledLogicCache = compiledCode;
+                }
+            } else {
+                throw new Error('Only TypeScript is supported at this time');
+            }
         }
+
+        if (requireTemplateLogic) {
+            let hasTemplateLogic = false;
+            for (const fileId of Object.keys(compiledCode)) {
+                const jsCode = compiledCode[fileId].code;
+                if (jsCode && /class\s+(\w+)\s+extends\s+TemplateLogic/.test(jsCode)) {
+                    hasTemplateLogic = true;
+                    break;
+                }
+            }
+            if (!hasTemplateLogic) {
+                throw new Error('Compilation failed: No class extending TemplateLogic was found.');
+            }
+        }
+
+        return compiledCode;
     }
 
     /**

--- a/test/TemplateArchiveProcessor.test.ts
+++ b/test/TemplateArchiveProcessor.test.ts
@@ -154,4 +154,29 @@ describe('template archive processor', () => {
 
         await expect(templateArchiveProcessor.trigger(validData, invalidRequest, stateResponse.state)).rejects.toThrow(/Namespace is not defined/i);
     });
+
+    test('should compile logic with requireTemplateLogic=true (success)', async () => {
+        const template = await Template.fromDirectory('test/archives/latedeliveryandpenalty-typescript', {offline: true});
+        const templateArchiveProcessor = new TemplateArchiveProcessor(template);
+        const compiledCode = await templateArchiveProcessor.compileLogic(false, true);
+        expect(compiledCode['logic/logic.ts']).toBeDefined();
+    });
+
+    test('should throw error when compile logic with requireTemplateLogic=true and no TemplateLogic subclass is present', async () => {
+        const template = await Template.fromDirectory('test/archives/latedeliveryandpenalty-typescript', {offline: true});
+        const templateArchiveProcessor = new TemplateArchiveProcessor(template);
+        const scripts = template.getLogicManager().getScriptManager().getScriptsForTarget('typescript');
+        const script = scripts.find((s: any) => s.getIdentifier() === 'logic/logic.ts');
+        const originalContents = script.getContents;
+        script.getContents = () => `
+            export function trigger(data: any, request: any, state: any) {
+                return { result: {}, state: {}, events: [] };
+            }
+        `;
+        try {
+            await expect(templateArchiveProcessor.compileLogic(false, true)).rejects.toThrow('Compilation failed: No class extending TemplateLogic was found.');
+        } finally {
+            script.getContents = originalContents;
+        }
+    });
 });


### PR DESCRIPTION
Closes #163

## Description
This PR adds support for strict validation of a `TemplateLogic` subclass during logic compilation, as requested in issue #163.

Specifically:
- We add a `requireTemplateLogic` boolean parameter to `compileLogic()` (defaulting to `false`).
- If `requireTemplateLogic` is set to `true`, the compiler scans all generated JavaScript modules for class declarations extending `TemplateLogic`.
- If no class definition extending `TemplateLogic` is found, a compilation error (`Compilation failed: No class extending TemplateLogic was found.`) is thrown.

This avoids the need for external execution environments/consumer applications to manually inspect or parse the compiled output.

## Verification
- Added two new unit tests in `test/TemplateArchiveProcessor.test.ts` to verify the success and failure behavior of `requireTemplateLogic` compilation options.
- All tests in `test/TemplateArchiveProcessor.test.ts` pass successfully.
