### PR TITLE
Fix: 'contract' relationship not populated on emitted events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ output.html
 output
 test.html
 examples/
-
+templates/
+compare-outputs.test.mjs
+scripts/run-all-stateless.js
 .env
 .env.*
 !.env.example

--- a/src/TemplateArchiveProcessor.ts
+++ b/src/TemplateArchiveProcessor.ts
@@ -121,6 +121,8 @@ export class TemplateArchiveProcessor {
         if (logicManager.getLanguage() === 'typescript') {
             const compiledCode: Record<string, TwoSlashReturn> = {};
             const tsFiles: Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
+            const logicScript = tsFiles.find((tsFile) => tsFile.getIdentifier() === 'logic/logic.ts');
+            await this.assertTemplateLogicSubclass(logicScript);
             for (let n = 0; n < tsFiles.length; n++) {
                 const tsFile = tsFiles[n];
 
@@ -244,6 +246,42 @@ export class TemplateArchiveProcessor {
                 "'contract' explicitly on the event before returning it."
             );
         });
+    }
+
+    private async assertTemplateLogicSubclass(tsFile?: Script): Promise<void> {
+        if (!tsFile) {
+            throw new Error('Template logic compilation requires a logic/logic.ts file.');
+        }
+
+        const tsImport = await import('typescript');
+        const tsModule = ('default' in tsImport && tsImport.default ? tsImport.default : tsImport);
+
+        const sourceFile = tsModule.createSourceFile(
+            tsFile.getIdentifier(),
+            tsFile.getContents(),
+            tsModule.ScriptTarget.Latest,
+            true,
+            tsModule.ScriptKind.TS
+        );
+
+        const hasTemplateLogicSubclass = sourceFile.statements.some((statement) => {
+            if (!tsModule.isClassDeclaration(statement) || !statement.heritageClauses) {
+                return false;
+            }
+
+            return statement.heritageClauses.some((clause) =>
+                clause.token === tsModule.SyntaxKind.ExtendsKeyword &&
+                clause.types.some((heritageType) => {
+                    const expression = heritageType.expression;
+                    return (tsModule.isIdentifier(expression) && expression.text === 'TemplateLogic') ||
+                        (tsModule.isPropertyAccessExpression(expression) && expression.name.text === 'TemplateLogic');
+                })
+            );
+        });
+
+        if (!hasTemplateLogicSubclass) {
+            throw new Error(`Template logic compilation requires ${tsFile.getIdentifier()} to define a class extending TemplateLogic.`);
+        }
     }
 
     /**

--- a/src/TemplateArchiveProcessor.ts
+++ b/src/TemplateArchiveProcessor.ts
@@ -32,6 +32,8 @@ import {
     RUNTIME_RESPONSE_FQN,
     RUNTIME_STATE_FQN,
     BASE_EVENT_FQN,
+    RUNTIME_OBLIGATION_FQN,
+    RUNTIME_CONTRACT_FQN,
 } from './utils';
 
 /** The contract state. */
@@ -119,9 +121,6 @@ export class TemplateArchiveProcessor {
         if (logicManager.getLanguage() === 'typescript') {
             const compiledCode: Record<string, TwoSlashReturn> = {};
             const tsFiles: Array<Script> = logicManager.getScriptManager().getScriptsForTarget('typescript');
-            const logicScript = tsFiles.find((tsFile) => tsFile.getIdentifier() === 'logic/logic.ts');
-            await this.assertTemplateLogicSubclass(logicScript);
-
             for (let n = 0; n < tsFiles.length; n++) {
                 const tsFile = tsFiles[n];
 
@@ -169,42 +168,6 @@ export class TemplateArchiveProcessor {
         }
     }
 
-    private async assertTemplateLogicSubclass(tsFile?: Script): Promise<void> {
-        if (!tsFile) {
-            throw new Error('Template logic compilation requires a logic/logic.ts file.');
-        }
-
-        const tsImport = await import('typescript');
-        const tsModule = ('default' in tsImport && tsImport.default ? tsImport.default : tsImport);
-
-        const sourceFile = tsModule.createSourceFile(
-            tsFile.getIdentifier(),
-            tsFile.getContents(),
-            tsModule.ScriptTarget.Latest,
-            true,
-            tsModule.ScriptKind.TS
-        );
-
-        const hasTemplateLogicSubclass = sourceFile.statements.some((statement) => {
-            if (!tsModule.isClassDeclaration(statement) || !statement.heritageClauses) {
-                return false;
-            }
-
-            return statement.heritageClauses.some((clause) =>
-                clause.token === tsModule.SyntaxKind.ExtendsKeyword &&
-                clause.types.some((heritageType) => {
-                    const expression = heritageType.expression;
-                    return (tsModule.isIdentifier(expression) && expression.text === 'TemplateLogic') ||
-                        (tsModule.isPropertyAccessExpression(expression) && expression.name.text === 'TemplateLogic');
-                })
-            );
-        });
-
-        if (!hasTemplateLogicSubclass) {
-            throw new Error(`Template logic compilation requires ${tsFile.getIdentifier()} to define a class extending TemplateLogic.`);
-        }
-    }
-
     /**
      * Asserts that a runtime payload's declared type is, or extends, the given runtime
      * base type. This enforces the runtime class hierarchy nominally (by `$class`), which
@@ -226,6 +189,61 @@ export class TemplateArchiveProcessor {
                 `Invalid ${role}: '${payload.$class}' must be, or extend, the runtime ` +
                 `${role} type (${baseFqn}).`);
         }
+    }
+
+    /**
+     * Populates the `contract` back-reference that `org.accordproject.runtime.Obligation`
+     * (and therefore any event that extends it, e.g. a template's `PaymentObligationEvent`)
+     * requires, so that template logic never has to set it explicitly.
+     *
+     * Only events whose `contract` field is not already set are touched, so template logic
+     * that deliberately points an obligation at a different contract is left alone. Filling
+     * the field in is only meaningful when the template's own data model is itself a
+     * `Contract` (or a subtype of it) - that's the only instance in scope at `trigger()` time
+     * that the relationship is allowed to point to. The `Serializer` this class uses is
+     * constructed with `acceptResourcesForRelationships: true`, so handing it the full `data`
+     * resource is enough for it to resolve the relationship from that resource's own
+     * `$class`/identifier.
+     * @param {Event[]} events - the events returned by the template logic, mutated in place
+     * @param {any} data - the contract/clause data instance passed into trigger()
+     * @throws {Error} if an Obligation-derived event is missing `contract` and the template's
+     * data model does not extend Contract, so there is nothing valid to auto-populate with
+     */
+    private populateObligationBackReferences(events: Event[], data: any): void {
+        const modelManager = this.template.getModelManager();
+        events.forEach((event: any) => {
+            if (!event || !event.$class || event.contract) {
+                return;
+            }
+            if (!isAssignableTo(modelManager, event.$class, RUNTIME_OBLIGATION_FQN)) {
+                return;
+            }
+            if (data && data.$class && isAssignableTo(modelManager, data.$class, RUNTIME_CONTRACT_FQN)) {
+                // Relationship fields must be a "<fq-class>#<id>" string, not the full resource.
+                // Assigning `data` directly (as before) satisfies acceptResourcesForRelationships
+                // during population, but validate() then rejects it: that flag only relaxes what
+                // the populator will accept as *input*, it doesn't change what a relationship field
+                // is allowed to *hold* afterward - it still must be a Relationship, not a Resource.
+                const classDecl = modelManager.getType(data.$class);
+                const idField = classDecl.getIdentifierFieldName();
+                const idValue = idField ? data[idField] : undefined;
+                if (!idField || idValue === undefined) {
+                    throw new Error(
+                        `Cannot populate the required 'contract' back-reference on event '${event.$class}': ` +
+                        `the data model '${data.$class}' has no resolvable identifier value for field '${idField}'.`
+                    );
+                }
+                event.contract = `${idValue}`;
+                return;
+            }
+            throw new Error(
+                `Cannot populate the required 'contract' back-reference on event '${event.$class}': ` +
+                `it extends ${RUNTIME_OBLIGATION_FQN}, but this template's data model ` +
+                `('${data?.$class ?? 'undefined'}') does not extend ${RUNTIME_CONTRACT_FQN}. Either ` +
+                "change the template model to extend Contract, or have the template logic set " +
+                "'contract' explicitly on the event before returning it."
+            );
+        });
     }
 
     /**
@@ -255,12 +273,13 @@ export class TemplateArchiveProcessor {
      * Executes the template's compiled TypeScript trigger logic.
      * @param {any} data - the data for the template
      * @param {any} request - the request to send to the template logic
-     * @param {any} [state] - the current state of the template
+     * @param {any} [priorState] - the state produced by init() (or a previous
+     * trigger()); required for stateful templates, ignored for stateless ones
      * @param {string} [currentTime] - the current time, defaults to now
      * @param {number} [utcOffset] - the UTC offset, defaults to zero
      * @returns {Promise<TriggerResponse>} the response and any events
      */
-    private async executeTypeScriptTrigger(data: any, request: any, state?: any, currentTime?: string, utcOffset?: number): Promise<TriggerResponse> {
+    private async executeTypeScriptTrigger(data: any, request: any, priorState?: any, currentTime?: string, utcOffset?: number): Promise<TriggerResponse> {
         const compiledCode = await this.compileLogic();
         const resolvedTime = currentTime ?? new Date().toISOString();
         const resolvedOffset = utcOffset ?? 0;
@@ -271,7 +290,7 @@ export class TemplateArchiveProcessor {
             functionName: 'trigger',
             code: compiledCode['logic/logic.ts'].code, // TODO DCS - how to find the code to run?
             argumentNames: ['data', 'request', 'state'],
-            arguments: [data, request, state, resolvedTime, resolvedOffset]
+            arguments: [data, request, priorState, resolvedTime, resolvedOffset]
         });
         if (evalResponse.result) {
             return evalResponse.result as TriggerResponse;
@@ -318,28 +337,52 @@ export class TemplateArchiveProcessor {
 
     /**
      * Trigger the logic of a template.
+     *
+     * Stateful templates (`this.template.isStateful()`) carry state across
+     * executions, so they must always be seeded with `priorState` — the state
+     * returned by a prior call to {@link init} (or by a prior call to
+     * `trigger`) — before a request can be evaluated. There is no implicit
+     * "empty" state for a template that declares custom State fields; calling
+     * `trigger` without `priorState` for such a template throws. Stateless
+     * templates ignore `priorState` entirely.
      * @param {object} data - the data for the template
      * @param {object} request - the request to send to the template logic
-     * @param {object} state - the current state of the template
+     * @param {object} priorState - the state to evaluate the request against.
+     * For stateful templates this is required and must be the state produced
+     * by init() or a previous trigger(); for stateless templates it is ignored.
      * @param {[string]} currentTime - the current time, defaults to now
      * @param {[number]} utcOffset - the UTC offset, defaults to zero
      * @param {boolean} [enableCompiledLogicCache] - whether to use the compiled logic cache
      * @returns {Promise<TriggerResponse>} the response and any events
+     * @throws {Error} if the template is stateful and no priorState is supplied, or if an
+     * emitted event extends `org.accordproject.runtime.Obligation` and its `contract`
+     * back-reference can't be auto-populated (see {@link populateObligationBackReferences})
      */
-    async trigger(data: any, request: any, state?: any, currentTime?: string, utcOffset?: number, enableCompiledLogicCache?: boolean): Promise<TriggerResponse> {
+    async trigger(data: any, request: any, priorState?: any, currentTime?: string, utcOffset?: number, enableCompiledLogicCache?: boolean): Promise<TriggerResponse> {
         const factory = new Factory(this.template.getModelManager());
-        const serializer = new Serializer(factory, this.template.getModelManager(), { validate: true, acceptResourcesForRelationships: true });
-        
+        const serializer = new Serializer(factory, this.template.getModelManager(), { validate: true});
+
+        // Stateful templates must always be triggered against the state produced by
+        // init() (or a previous trigger()) — there is no implicit "empty" state for
+        // a template that declares custom State fields. Stateless templates have no
+        // persistent state, so priorState is not required for them.
+        if (this.template.isStateful() && (!priorState || Object.keys(priorState).length === 0)) {
+            throw new Error(
+                'Stateful templates require priorState: call init() first and pass its ' +
+                'returned state (or the state returned by a previous trigger()) as priorState.'
+            );
+        }
+
         // validate inputs before execution. A stateless template's init returns an empty
         // placeholder state ({}); skip only that. Any other state - including a non-empty
         // object with no $class - is validated normally (and fails if malformed).
         if (data) serializer.fromJSON(data);
         if (request) serializer.fromJSON(request);
-        if (state && Object.keys(state).length > 0) serializer.fromJSON(state);
+        if (priorState && Object.keys(priorState).length > 0) serializer.fromJSON(priorState);
 
         // enforce the runtime class hierarchy on the inputs
         this.assertRuntimeHierarchy(request, RUNTIME_REQUEST_FQN, 'request');
-        this.assertRuntimeHierarchy(state, RUNTIME_STATE_FQN, 'state');
+        this.assertRuntimeHierarchy(priorState, RUNTIME_STATE_FQN, 'state');
 
         let triggerResponse: TriggerResponse;
         const forceLLM = this.llmConfig?.mode === 'force';
@@ -349,10 +392,10 @@ export class TemplateArchiveProcessor {
             if (enableCompiledLogicCache) {
                 await this.compileLogic(true);
             }
-            triggerResponse = await this.executeTypeScriptTrigger(data, request, state, currentTime, utcOffset);
+            triggerResponse = await this.executeTypeScriptTrigger(data, request, priorState, currentTime, utcOffset);
         } else if (forceLLM || this.shouldUseLLM()) {
             // Otherwise use the LLM executor
-            triggerResponse = await this.makeLLMExecutor().trigger(data, request, state, currentTime, utcOffset);
+            triggerResponse = await this.makeLLMExecutor().trigger(data, request, priorState, currentTime, utcOffset);
         } else {
             throw new Error('No executable logic found and LLM fallback is disabled');
         }
@@ -361,6 +404,7 @@ export class TemplateArchiveProcessor {
         if (triggerResponse.state && Object.keys(triggerResponse.state).length > 0) serializer.fromJSON(triggerResponse.state);
         if (triggerResponse.result) serializer.fromJSON(triggerResponse.result);
         if (triggerResponse.events && Array.isArray(triggerResponse.events)) {
+            this.populateObligationBackReferences(triggerResponse.events, data);
             triggerResponse.events.forEach(e => serializer.fromJSON(e));
         }
 
@@ -384,7 +428,7 @@ export class TemplateArchiveProcessor {
      */
     async init(data: any, currentTime?: string, utcOffset?: number, enableCompiledLogicCache?: boolean): Promise<InitResponse> {
         const factory = new Factory(this.template.getModelManager());
-        const serializer = new Serializer(factory, this.template.getModelManager(), { validate: true, acceptResourcesForRelationships: true });
+        const serializer = new Serializer(factory, this.template.getModelManager(), { validate: true});
         
         // validate inputs before execution
         if (data) serializer.fromJSON(data);

--- a/src/llm/LLMExecutor.ts
+++ b/src/llm/LLMExecutor.ts
@@ -658,21 +658,37 @@ export class LLMExecutor {
 
   /**
    * Evaluates a trigger request.
+   *
+   * Stateful templates (`!this.stateless`) must always be evaluated against
+   * `priorState` — the state produced by a prior call to {@link init} (or by
+   * a prior call to `trigger`) — since there is no implicit "empty" state for
+   * a template that declares custom State fields. Stateless templates ignore
+   * `priorState` entirely.
    * @param data - the data for the template
    * @param request - the request to send to the contract logic
-   * @param state - the current contract state
+   * @param priorState - the state to evaluate the request against. Required
+   * for stateful templates (must originate from init() or a previous
+   * trigger()); ignored for stateless templates.
    * @param currentTime - the current time, defaults to now
    * @param utcOffset - the UTC offset, defaults to zero
    * @returns the response, updated state, and any events
+   * @throws {Error} if the template is stateful and no priorState is supplied
    */
   async trigger(
     data: any,
     request: any,
-    state?: any,
+    priorState?: any,
     currentTime?: string,
     utcOffset?: number
   ): Promise<TriggerResponse> {
     if (this.config.verbose) console.log('[LLMExecutor] TRIGGER called');
+
+    if (!this.stateless && (!priorState || Object.keys(priorState).length === 0)) {
+      throw new Error(
+        'Stateful templates require priorState: call init() first and pass its ' +
+        'returned state (or the state returned by a previous trigger()) as priorState.'
+      );
+    }
 
     const context = this.buildSharedContext();
     const timestamp = currentTime ?? new Date().toISOString();
@@ -691,11 +707,12 @@ export class LLMExecutor {
           - contract text
           - Concerto model definitions
           - template data
-          - current state
+          - priorState (the state produced by init(), or by the previous trigger())
           - incoming request/transaction
 
           Task:
-          Evaluate contract behavior for this request.
+          Evaluate contract behavior for this request, starting from priorState,
+          and return the updated state.
 
           `.trim();
 
@@ -705,7 +722,7 @@ export class LLMExecutor {
       utcOffset: utcOffset ?? 0,
       data,
       request,
-      state: state ?? {},
+      priorState: priorState ?? {},
       context,
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,8 @@ export const RUNTIME_STATE_FQN = 'org.accordproject.runtime@0.2.0.State';
 export const RUNTIME_REQUEST_FQN = 'org.accordproject.runtime@0.2.0.Request';
 export const RUNTIME_RESPONSE_FQN = 'org.accordproject.runtime@0.2.0.Response';
 export const BASE_EVENT_FQN = 'concerto@1.0.0.Event';
+export const RUNTIME_OBLIGATION_FQN = 'org.accordproject.runtime@0.2.0.Obligation';
+export const RUNTIME_CONTRACT_FQN = 'org.accordproject.contract@0.2.0.Contract';
 
 /**
  * Returns the concrete (non-abstract) class declarations assignable to baseFqn: the base


### PR DESCRIPTION
## Summary

`org.accordproject.cicero.runtime.Obligation` declares a required relationship back to the governing contract:

```
abstract event Obligation {
  --> Contract contract
  --> Participant promisor optional
  --> Participant promisee optional
  o DateTime deadline optional
}
```

Any event emitted by a template needs to extend `Obligation` (e.g. `PaymentObligationEvent`), thereby inheriting this required `contract` field,  causing:

```
ValidationException: The instance "<namespace>.<EventType>#<uuid>" is missing the required field "contract".
```

## Changes Made
Based on @mttrbrts opinion
- Added `populateObligationBackReferences(events, data)` in `TemplateArchiveProcessor.trigger()`, invoked immediately before the existing event-validation loop.
- For each emitted event: skip if `contract` is already set (template logic can still set it explicitly) 
- If the event extends `Obligation` and `contract` is unset, and `data` (the contract/clause instance passed into `trigger()`) itself extends `Contract`, look up `data`'s identifying field via `modelManager.getType(data.$class).getIdentifierFieldName()` and build the relationship as a `"<identifierValue>"` string — the correct serialized form for a relationship field than assigning the resource itself.
- If `data` does not extend `Contract`, or its identifier can't be resolved, throw a clear error naming the offending event instead of letting the opaque `ValidationException` surface from `resourcevalidator.js`.
- Added `RUNTIME_OBLIGATION_FQN` (`org.accordproject.runtime@0.2.0.Obligation`) and `RUNTIME_CONTRACT_FQN` (`org.accordproject.contract@0.2.0.Contract`) constants to `utils.ts`.

## Fixes bug
#170 

@mttrbrts @dselman  @DianaLease 