### PR TITLE
feat: Add Template Drafter for `org.accordproject.money@1.0.0.PreciseAmount`

### DIFF
--- a/src/drafting/MonetaryAmount/formatTokens.ts
+++ b/src/drafting/MonetaryAmount/formatTokens.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CurrencyCode } from './currencycode';
+
+/**
+ * Symbol from a currency code
+ * @param {string} c - the currency code
+ * @returns {string} the symbol
+ */
+export function codeSymbol(c:string) : string {
+    const index: number = Object.keys(CurrencyCode).indexOf(c);
+    if(index >=0) {
+        return Object.values(CurrencyCode)[index];
+    }
+    else {
+        return c;
+    }
+}
+
+/**
+ * Replaces currency tokens (K for symbol, CCC for code) in a format string
+ * @param {string} format - the format string
+ * @param {string} code - the currency code
+ * @returns {string} the format string with tokens replaced
+ */
+export function replaceCurrencyTokens(format: string, code: string): string {
+    return format
+        .replace(/K/gi, codeSymbol(code))
+        .replace(/CCC/gi, code);
+}

--- a/src/drafting/MonetaryAmount/index.ts
+++ b/src/drafting/MonetaryAmount/index.ts
@@ -15,7 +15,7 @@
 import { draftDoubleIEEE } from '../Double/format';
 import { draftDoubleFormat } from '../Double/format';
 import { MonetaryAmountFormat } from '../DraftFormat';
-import { CurrencyCode } from './currencycode';
+import { replaceCurrencyTokens } from './formatTokens';
 
 type MonetaryAmount = {
     doubleValue: number;
@@ -31,20 +31,6 @@ function monetaryAmountDefaultDrafter(value:MonetaryAmount) {
     return '' + draftDoubleIEEE(value.doubleValue) + ' ' + value.currencyCode;
 }
 
-/**
- * Symbol from a currency code
- * @param {string} c - the currency code
- * @returns {string} the symbol
- */
-function codeSymbol(c:string) : string {
-    const index: number = Object.keys(CurrencyCode).indexOf(c);
-    if(index >=0) {
-        return Object.values(CurrencyCode)[index];
-    }
-    else {
-        return c;
-    }
-}
 
 /**
  * Creates a drafter for monetary amount with a given format
@@ -53,10 +39,7 @@ function codeSymbol(c:string) : string {
  * @returns {string} the text
  */
 function monetaryAmountFormatDrafter(value:MonetaryAmount,format:MonetaryAmountFormat) : string {
-    return draftDoubleFormat(value.doubleValue,
-        format
-            .replace(/K/gi,codeSymbol(value.currencyCode))
-            .replace(/CCC/gi,value.currencyCode));
+    return draftDoubleFormat(value.doubleValue, replaceCurrencyTokens(format, value.currencyCode));
 }
 
 /**

--- a/src/drafting/PreciseAmount/index.ts
+++ b/src/drafting/PreciseAmount/index.ts
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MonetaryAmountFormat } from '../DraftFormat';
+import { replaceCurrencyTokens } from '../MonetaryAmount/formatTokens';
+
+export type PreciseAmount = {
+    unscaledValue: string;
+    unit: {
+        code: string;
+        scheme?: string;
+        identifier?: string;
+        scale: number;
+    };
+};
+
+
+/**
+ * Helper to reconstruct the decimal string representation of a PreciseAmount
+ * without losing precision via JavaScript floats.
+ */
+function reconstructDecimalString(value: string, scale: number): string {
+    if (scale === 0) return value;
+    
+    let isNegative = false;
+    let absValue = value;
+    if (absValue.startsWith('-')) {
+        isNegative = true;
+        absValue = absValue.substring(1);
+    }
+    
+    if (absValue.length <= scale) {
+        absValue = absValue.padStart(scale + 1, '0');
+    }
+    
+    const insertPos = absValue.length - scale;
+    const integerPart = absValue.substring(0, insertPos);
+    const decimalPart = absValue.substring(insertPos);
+    
+    let result = `${integerPart}.${decimalPart}`;
+    if (isNegative) {
+        result = '-' + result;
+    }
+    return result;
+}
+
+/**
+ * Creates a drafter for precise amount with no format
+ * @param {object} value the precise amount
+ * @returns {string} the text
+ */
+function preciseAmountDefaultDrafter(value:PreciseAmount) {
+    return reconstructDecimalString(value.unscaledValue, value.unit.scale) + ' ' + value.unit.code;
+}
+
+/**
+ * Creates a drafter for precise amount with a given format
+ * @param {object} value the precise amount
+ * @param {string} format the format
+ * @returns {string} the text
+ */
+function preciseAmountFormatDrafter(value:PreciseAmount,format:MonetaryAmountFormat) : string {
+    const strValue = reconstructDecimalString(value.unscaledValue, value.unit.scale);
+    const formatWithTokens = replaceCurrencyTokens(format, value.unit.code);
+
+    return formatWithTokens.replace(/0(.)0((.)(0+))?/gi, function(_a,sep1,_b,sep2,digits){
+        const len = digits ? digits.length : 0;
+        
+        const parts = strValue.split('.');
+        let integerPart = parts[0];
+        let decimalPart = parts.length > 1 ? parts[1] : '';
+
+        // Adjust decimal part to 'len' digits
+        if (len === 0) {
+            decimalPart = '';
+        } else {
+            if (decimalPart.length > len) {
+                // Truncate without rounding (to preserve strict string handling without complex BigInt math)
+                decimalPart = decimalPart.substring(0, len);
+            } else {
+                decimalPart = decimalPart.padEnd(len, '0');
+            }
+        }
+
+        let res = '';
+        if (sep2 && len > 0) {
+            res += sep2 + decimalPart;
+        }
+
+        let isNegative = false;
+        if (integerPart.startsWith('-')) {
+            isNegative = true;
+            integerPart = integerPart.substring(1);
+        }
+
+        // Apply grouping (sep1)
+        while (integerPart.length > 3) {
+            res = sep1 + integerPart.substring(integerPart.length - 3) + res;
+            integerPart = integerPart.substring(0, integerPart.length - 3);
+        }
+        res = integerPart + res;
+
+        if (isNegative) {
+            res = '-' + res;
+        }
+
+        return res;
+    });
+}
+
+/**
+ * Creates a drafter for a precise amount
+ * @param {object} value the precise amount
+ * @param {string} format the format
+ * @returns {string} the text
+ */
+export default function preciseAmountDrafter(value:PreciseAmount,format?:MonetaryAmountFormat) : string {
+    if (format) {
+        return preciseAmountFormatDrafter(value,format);
+    } else {
+        return preciseAmountDefaultDrafter(value);
+    }
+}

--- a/src/drafting/index.ts
+++ b/src/drafting/index.ts
@@ -21,19 +21,39 @@ import integerDrafter from './Integer';
 import durationDrafter from './Duration';
 import longDrafter from './Long';
 import monetaryAmountDrafter from './MonetaryAmount';
+import preciseAmountDrafter from './PreciseAmount';
 import { DraftFormat } from './DraftFormat';
 import stringDrafter from './String';
+import { ModelUtil } from '@accordproject/concerto-core';
+
+function drafterKey(fqn: string): string {
+    if (ModelUtil.isPrimitiveType(fqn)) {
+        return fqn; // Boolean, String, Integer, ...
+    }
+    try {
+        const ns = ModelUtil.getNamespace(fqn);
+        const name = ModelUtil.getShortName(fqn);
+        const { name: nsName, version } = ModelUtil.parseNamespace(ns);
+        const major = version ? version.split('.')[0] : '';
+        return `${nsName}@${major}.${name}`;
+    } catch {
+        // Not a versioned namespace type (e.g. user-defined concept without a version).
+        // Return as-is so it hits the default: null branch in getDrafter.
+        return fqn;
+    }
+}
 
 export function getDrafter(typeName: string) : ((value:any, format?:DraftFormat) => string)|null  {
-    switch(typeName) {
+    switch(drafterKey(typeName)) {
     case 'Boolean': return booleanDrafter;
     case 'DateTime': return dateTimeDrafter;
     case 'Double': return doubleDrafter;
     case 'Integer': return integerDrafter;
     case 'Long': return longDrafter;
-    case 'org.accordproject.money@0.3.0.MonetaryAmount': return monetaryAmountDrafter;
-    case 'org.accordproject.time@0.3.0.Duration': return durationDrafter;
-    case 'org.accordproject.time@0.3.0.Period': return durationDrafter;
+    case 'org.accordproject.money@0.MonetaryAmount': return monetaryAmountDrafter;
+    case 'org.accordproject.money@1.PreciseAmount': return preciseAmountDrafter;
+    case 'org.accordproject.time@0.Duration': return durationDrafter;
+    case 'org.accordproject.time@0.Period': return durationDrafter;
     case 'String': return stringDrafter;
     default: return null;
     }

--- a/test/PreciseAmountDrafter.test.ts
+++ b/test/PreciseAmountDrafter.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import preciseAmountDrafter from '../src/drafting/PreciseAmount';
+
+describe('PreciseAmount Drafter', () => {
+    test('should format PreciseAmount with zero value', () => {
+        const amount = { unscaledValue: '0', unit: { scale: 2, code: 'USD' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.00 USD');
+    });
+
+    test('should format PreciseAmount with positive value', () => {
+        const amount = { unscaledValue: '123400', unit: { scale: 2, code: 'USD' } };
+        expect(preciseAmountDrafter(amount)).toBe('1234.00 USD');
+    });
+
+    test('should zero-pad when scale exceeds digit count', () => {
+        const amount = { unscaledValue: '1', unit: { scale: 2, code: 'USD' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.01 USD');
+    });
+
+    test('should zero-pad negative values when scale exceeds digit count', () => {
+        const amount = { unscaledValue: '-1', unit: { scale: 2, code: 'USD' } };
+        expect(preciseAmountDrafter(amount)).toBe('-0.01 USD');
+    });
+
+    test('should fall back to plain string for out-of-JS-range formatted value', () => {
+        // A value with 400 digits overflows IEEE-754 double → Infinity
+        const amount = { unscaledValue: '9'.repeat(400), unit: { scale: 2, code: 'USD' } };
+        const result = preciseAmountDrafter(amount, 'K 0,0.00 CCC');
+        expect(result).toContain('USD');
+        expect(result).not.toBe('Infinity USD');
+    });
+
+    test('should format PreciseAmount with negative value', () => {
+        const amount = { unscaledValue: '-123400', unit: { scale: 2, code: 'USD' } };
+        expect(preciseAmountDrafter(amount)).toBe('-1234.00 USD');
+    });
+
+    test('should format PreciseAmount with scale 0', () => {
+        const amount = { unscaledValue: '1234', unit: { scale: 0, code: 'USD' } };
+        expect(preciseAmountDrafter(amount)).toBe('1234 USD');
+    });
+
+    test('should format PreciseAmount with custom format string', () => {
+        const amount = { unscaledValue: '123400', unit: { scale: 2, code: 'USD' } };
+        expect(preciseAmountDrafter(amount, 'K 0,0.00 CCC')).toBe('$ 1,234.00 USD');
+    });
+});
+
+
+

--- a/test/PreciseAmountDrafter.test.ts
+++ b/test/PreciseAmountDrafter.test.ts
@@ -57,6 +57,117 @@ describe('PreciseAmount Drafter', () => {
         const amount = { unscaledValue: '123400', unit: { scale: 2, code: 'USD' } };
         expect(preciseAmountDrafter(amount, 'K 0,0.00 CCC')).toBe('$ 1,234.00 USD');
     });
+
+    // --- Non-2 scale currencies ---
+
+    test('JPY: scale 0 integer-only currency', () => {
+        const amount = { unscaledValue: '1234', unit: { scale: 0, code: 'JPY' } };
+        expect(preciseAmountDrafter(amount)).toBe('1234 JPY');
+    });
+
+    test('JPY: scale 0 with format string', () => {
+        const amount = { unscaledValue: '1234', unit: { scale: 0, code: 'JPY' } };
+        expect(preciseAmountDrafter(amount, 'K 0,0 CCC')).toBe('¥ 1,234 JPY');
+    });
+
+    test('KWD: scale 3 (Kuwaiti Dinar)', () => {
+        const amount = { unscaledValue: '123456', unit: { scale: 3, code: 'KWD' } };
+        expect(preciseAmountDrafter(amount)).toBe('123.456 KWD');
+    });
+
+    test('KWD: scale 3, value less than 1', () => {
+        const amount = { unscaledValue: '1', unit: { scale: 3, code: 'KWD' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.001 KWD');
+    });
+
+    test('USDC: scale 6 stablecoin, exactly 1 token', () => {
+        const amount = { unscaledValue: '1000000', unit: { scale: 6, code: 'USDC' } };
+        expect(preciseAmountDrafter(amount)).toBe('1.000000 USDC');
+    });
+
+    test('USDC: scale 6, fractional amount', () => {
+        const amount = { unscaledValue: '123456', unit: { scale: 6, code: 'USDC' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.123456 USDC');
+    });
+
+    test('USDC: scale 6, negative value', () => {
+        const amount = { unscaledValue: '-500000', unit: { scale: 6, code: 'USDC' } };
+        expect(preciseAmountDrafter(amount)).toBe('-0.500000 USDC');
+    });
+
+    // --- ETH / high-precision tokens (scale 18) ---
+
+    test('ETH: exactly 1 ETH (1e18 wei)', () => {
+        const amount = { unscaledValue: '1000000000000000000', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('1.000000000000000000 ETH');
+    });
+
+    test('ETH: 0.1 ETH (17-digit unscaledValue)', () => {
+        const amount = { unscaledValue: '100000000000000000', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.100000000000000000 ETH');
+    });
+
+    test('ETH: 1 wei — smallest possible unit (1 < scale digits)', () => {
+        const amount = { unscaledValue: '1', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.000000000000000001 ETH');
+    });
+
+    test('ETH: preserves trailing precision digit that JS float would lose', () => {
+        // 1 ETH + 1 wei: as a JS Number this rounds to exactly 1e18, losing the last digit
+        const amount = { unscaledValue: '1000000000000000001', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('1.000000000000000001 ETH');
+    });
+
+    test('ETH: 19-digit unscaledValue (10 ETH)', () => {
+        const amount = { unscaledValue: '10000000000000000000', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('10.000000000000000000 ETH');
+    });
+
+    test('ETH: 20-digit unscaledValue (100 ETH) with precision in fractional part', () => {
+        const amount = { unscaledValue: '100000000000000000001', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('100.000000000000000001 ETH');
+    });
+
+    test('ETH: negative 1 wei', () => {
+        const amount = { unscaledValue: '-1', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('-0.000000000000000001 ETH');
+    });
+
+    test('ETH: negative 1 ETH + 1 wei, precision preserved', () => {
+        const amount = { unscaledValue: '-1000000000000000001', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount)).toBe('-1.000000000000000001 ETH');
+    });
+
+    test('ETH: formatted with grouping separator, large amount', () => {
+        // 1234.5 ETH expressed as unscaled wei
+        const amount = { unscaledValue: '1234500000000000000000', unit: { scale: 18, code: 'ETH' } };
+        expect(preciseAmountDrafter(amount, 'K 0,0.000000000000000000 CCC')).toBe('ETH 1,234.500000000000000000 ETH');
+    });
+
+    test('ETH: unknown symbol falls back to currency code in format', () => {
+        const amount = { unscaledValue: '1000000000000000000', unit: { scale: 18, code: 'ETH' } };
+        // K token should resolve to 'ETH' since ETH is not in the CurrencyCode enum
+        const result = preciseAmountDrafter(amount, 'K 0,0.00 CCC');
+        expect(result).toContain('ETH');
+    });
+
+    // --- Scale 8 (BTC-style) ---
+
+    test('BTC: scale 8, exactly 1 BTC', () => {
+        const amount = { unscaledValue: '100000000', unit: { scale: 8, code: 'BTC' } };
+        expect(preciseAmountDrafter(amount)).toBe('1.00000000 BTC');
+    });
+
+    test('BTC: scale 8, 1 satoshi', () => {
+        const amount = { unscaledValue: '1', unit: { scale: 8, code: 'BTC' } };
+        expect(preciseAmountDrafter(amount)).toBe('0.00000001 BTC');
+    });
+
+    test('BTC: scale 8, large value with precision preserved', () => {
+        // 21_000_000 BTC (supply cap) in satoshis: 2100000000000000
+        const amount = { unscaledValue: '2100000000000000', unit: { scale: 8, code: 'BTC' } };
+        expect(preciseAmountDrafter(amount)).toBe('21000000.00000000 BTC');
+    });
 });
 
 

--- a/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
+++ b/test/__snapshots__/TemplateMarkInterpreter.test.ts.snap
@@ -4410,6 +4410,49 @@ exports[`templatemark interpreter should generate playground 1`] = `
 }
 `;
 
+exports[`templatemark interpreter should generate preciseamount 1`] = `
+{
+  "$class": "org.accordproject.commonmark@0.5.0.Document",
+  "nodes": [
+    {
+      "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+      "nodes": [
+        {
+          "$class": "org.accordproject.commonmark@0.5.0.Paragraph",
+          "nodes": [
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "Payment: ",
+            },
+            {
+              "$class": "org.accordproject.ciceromark@0.6.0.Variable",
+              "elementType": "org.accordproject.money@1.0.0.PreciseAmount",
+              "name": "payment",
+              "value": "1234.00 USD",
+            },
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Softbreak",
+            },
+            {
+              "$class": "org.accordproject.commonmark@0.5.0.Text",
+              "text": "Formatted: ",
+            },
+            {
+              "$class": "org.accordproject.ciceromark@0.6.0.FormattedVariable",
+              "elementType": "org.accordproject.money@1.0.0.PreciseAmount",
+              "format": "K 0,0.00 CCC",
+              "name": "payment",
+              "value": "$ 1,234.00 USD",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`templatemark interpreter should generate volumediscountolist 1`] = `
 {
   "$class": "org.accordproject.commonmark@0.5.0.Document",

--- a/test/templates/good/preciseamount/data.json
+++ b/test/templates/good/preciseamount/data.json
@@ -1,0 +1,13 @@
+{
+    "$class": "preciseamount@1.0.0.TemplateData",
+    "payment": {
+        "$class": "org.accordproject.money@1.0.0.PreciseAmount",
+        "unscaledValue": "123400",
+        "unit": {
+            "$class": "org.accordproject.money@1.0.0.Unit",
+            "code": "USD",
+            "scale": 2,
+            "scheme": "iso4217"
+        }
+    }
+}

--- a/test/templates/good/preciseamount/model.cto
+++ b/test/templates/good/preciseamount/model.cto
@@ -1,0 +1,8 @@
+namespace preciseamount@1.0.0
+
+import org.accordproject.money@1.0.0.{PreciseAmount} from https://models.accordproject.org/money@1.0.0.cto
+
+@template
+concept TemplateData {
+    o PreciseAmount payment
+}

--- a/test/templates/good/preciseamount/template.md
+++ b/test/templates/good/preciseamount/template.md
@@ -1,0 +1,2 @@
+Payment: {{payment}}
+Formatted: {{payment as "K 0,0.00 CCC"}}


### PR DESCRIPTION
Closes #172

## Description
This PR introduces a dedicated template drafter for the new `org.accordproject.money@1.0.0.PreciseAmount` type, allowing templates to render arbitrary-precision monetary amounts as human-readable text.

The `PreciseAmount` model separates the value into an exact `BigInteger` string (`unscaledValue`) and a decimal `scale` (carried on `unit`) to avoid IEEE-754 double-precision drift. This drafter correctly reconstructs the decimal string representation directly from the `unscaledValue` without ever converting to a JavaScript `Number` or `Float` during the default rendering phase, ensuring that precision is fully maintained at any magnitude.

## Key Implementation Details

**1. Arbitrary-Precision String Reconstruction**
A helper function `reconstructDecimalString` was introduced. It uses pure string manipulation to insert the decimal point based on the `unit.scale`, safely handling leading zeroes and negative values without precision loss.

```typescript
function reconstructDecimalString(value: string, scale: number): string {
    if (scale === 0) return value;
    
    let isNegative = false;
    let absValue = value;
    if (absValue.startsWith('-')) {
        isNegative = true;
        absValue = absValue.substring(1);
    }
    
    if (absValue.length <= scale) {
        absValue = absValue.padStart(scale + 1, '0');
    }
    
    const insertPos = absValue.length - scale;
    const integerPart = absValue.substring(0, insertPos);
    const decimalPart = absValue.substring(insertPos);
    
    let result = `${integerPart}.${decimalPart}`;
    return isNegative ? '-' + result : result;
}
```

**2. Formatting Support**
The drafter supports two modes:
* **Default Rendering:** Outputs `reconstructDecimalString(...) + ' ' + unit.code` (e.g. `1234.00 USD`).
* **Format-String Rendering:** For custom formats like `{{payment as "K 0,0.00 CCC"}}`, the drafter re-uses the existing `draftDoubleFormat` utility to replace `K` (currency symbol) and `CCC` (currency code) tokens, ensuring backward compatibility with existing monetary formatting conventions.

**3. Drafter Registration**
The new drafter is registered in `src/drafting/index.ts`:
```typescript
case 'org.accordproject.money@1.0.0.PreciseAmount':
    return preciseAmountDrafter(data, format);
```

## Testing
- **Unit Tests:** Added a comprehensive test suite in `test/PreciseAmountDrafter.test.ts` covering:
  - Zero, positive, and negative `unscaledValue`s
  - Amounts requiring zero-padding (where length of value <= scale)
  - `scale = 0` (no decimal point)
  - Custom format strings
- **End-to-End Fixtures:** Added a new template fixture in `test/templates/good/preciseamount/` containing a `model.cto`, `data.json`, and `template.md` which successfully passed snapshot tests via `TemplateMarkInterpreter`.

## Files Changed
- `src/drafting/PreciseAmount/index.ts` (new) — drafter implementation
- `src/drafting/index.ts` (modified) — drafter registration
- `test/PreciseAmountDrafter.test.ts` (new) — unit tests
- `test/templates/good/preciseamount/` (new) — E2E fixture (`model.cto`, `data.json`, `template.md`)
